### PR TITLE
* Iterate using foreach to allow batch indexing of associative arrays

### DIFF
--- a/algoliasearch.php
+++ b/algoliasearch.php
@@ -562,8 +562,7 @@ class Index {
      */
     private function buildBatch($action, $objects, $withObjectID, $objectIDKey = "objectID") {
         $requests = array();
-        for ($i = 0; $i < count($objects); ++$i) {
-            $obj = $objects[$i];
+        foreach ($objects as $obj) {
             $req = array("action" => $action, "body" => $obj);
             if ($withObjectID && array_key_exists($objectIDKey, $obj)) {
                 $req["objectID"] = (string) $obj[$objectIDKey];


### PR DESCRIPTION
Iterate using foreach to allow batch indexing of associative arrays instead of strictly 0 based increasing key based arrays.
