### PR TITLE
catching the correct exception in AlgoliaUtils_request

### DIFF
--- a/algoliasearch.php
+++ b/algoliasearch.php
@@ -697,7 +697,7 @@ function AlgoliaUtils_request($curlHandle, $hostsArray, $method, $path, $params 
                 return $res;
         } catch (AlgoliaException $e) {
             throw $e;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $exception = $e;
         }
     }


### PR DESCRIPTION
AlgoliaUtils_request was failing to try all hosts because the exception being caught (Exception) was not the same as the exception being thrown (\Exception). Changing Exception to \Exception will make AlgoliaUtils_request try all hosts.
