### PR TITLE
Fix #26: move the version to a PHP const for performances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "algolia/algoliasearch-client-php",
-    "version": "1.5.3",
     "description": "Algolia Search API Client for PHP",
     "type": "library",
     "homepage": "https://github.com/algolia/algoliasearch-client-php",
@@ -20,6 +19,7 @@
         }
     ],
     "require": {
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "satooshi/php-coveralls": "dev-master",

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -374,7 +374,7 @@ class Client {
                     'Content-type: application/json'
                     ), $context->headers));
         }
-        curl_setopt($curlHandle, CURLOPT_USERAGENT, "Algolia for PHP " . Version::getValue());
+        curl_setopt($curlHandle, CURLOPT_USERAGENT, "Algolia for PHP " . Version::VALUE);
         //Return the output instead of printing it
         curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -34,7 +34,6 @@ class Index {
     private $indexName;
     private $client;
     private $urlIndexName;
-    private $curlHandle;
 
     /*
      * Index initialization (You should not call this initialized yourself)
@@ -559,6 +558,7 @@ class Index {
      * @param  $objects the array of objects
      * @param  $withObjectID set an 'objectID' attribute
      * @param  $objectIDKey the objectIDKey
+     * @return array
      */
     private function buildBatch($action, $objects, $withObjectID, $objectIDKey = "objectID") {
         $requests = array();

--- a/src/AlgoliaSearch/Version.php
+++ b/src/AlgoliaSearch/Version.php
@@ -26,26 +26,5 @@
 namespace AlgoliaSearch;
 
 class Version {
-
-  static $value;
-
-  public static function getValue() {
-    if (!isset(self::$value)) {
-      $vpath = dirname(__FILE__) . "/../../composer.json";
-      if (file_exists($vpath)) {
-        $composerJson = file_get_contents($vpath);
-        if ($composerJson != false) {
-          $composer = json_decode($composerJson);
-          if ($composer != null) {
-            self::$value = $composer->version;
-            return self::$value;
-          }
-        }
-      }
-      self::$value = "N/A";
-    } else {
-      return self::$value;
-    }
-  }
-
+  const VALUE = "1.5.4";
 }

--- a/tests/AlgoliaSearch/Tests/BasicTest.php
+++ b/tests/AlgoliaSearch/Tests/BasicTest.php
@@ -25,7 +25,7 @@ class BasicTest extends AlgoliaSearchTestCase
     protected function tearDown()
     {
         try {
-            $this->client->deleteIndex($this->safe_name('àlgol?à-php'));            
+            $this->client->deleteIndex($this->safe_name('àlgol?à-php'));
         } catch (AlgoliaException $e) {
             // not fatal
         }


### PR DESCRIPTION
No more filesystem access for this version header.

- also fix some minor coding std (un-used var, missing return)
- also add mbstring as composer dependency - help to detect not compatible PHP installations (mbstring is not installed by default in CentOs and all other "yum" based systems).