### PR TITLE
Add Framework Integrations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,9 @@ $res = $client->getLogs();
 $res = $client->getLogs(0, 100);
 ```
 
+## Framework Integrations
+ - **Laravel** - https://github.com/vinkla/algolia
+ - **Symfony** - https://github.com/GoldenLine/AlgoliaBundle
 
-
-
+If you have integrated Algolia into a popular PHP framework let us know!
 


### PR DESCRIPTION
Let's add links to framework integrations to help developers find pre-made framework integrations for the Algolia package.