### PR TITLE
Added support for proxy 

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -34,6 +34,7 @@ class Client {
 
     protected $context;
     protected $cainfoPath;
+    protected $curlOptions = [];
 
     /*
      * Algolia Search initialization
@@ -57,6 +58,8 @@ class Client {
         foreach ($options as $option => $value) {
             if ($option == "cainfo") {
                 $this->cainfoPath = $value;
+            } elseif ($option == "curl-options" and is_array($value)) {
+                $this->curlOptions = $value;
             } else {
                 throw new \Exception('Unknown option: ' . $option);
             }
@@ -412,6 +415,12 @@ class Client {
         }
         // initialize curl library
         $curlHandle = curl_init();
+        
+        // set curl options
+        foreach ($this->curlOptions as $curlOption => $value) {
+            curl_setopt($curlHandle, $curlOption, $value);
+        }
+
         //curl_setopt($curlHandle, CURLOPT_VERBOSE, true);
         if ($context->adminAPIKey == null) {
             curl_setopt($curlHandle, CURLOPT_HTTPHEADER, array_merge(array(


### PR DESCRIPTION
Added support for custom curl options like CURLOPT_PROXY
On construct you can specified an array with curl options:

```php
$options = ['curl-options' => [CURLOPT_PROXY => 'tcp://1.2.3.4:80']];
$client = new Client(
            'app-id',
            'admin_api_key',
            null,
            $options
        );
```

