### PR TITLE
Add forwared ip and user token headers

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -107,6 +107,28 @@ class Client {
         $this->context->setRateLimit($adminAPIKey, $endUserIP, $rateLimitAPIKey);
     }
 
+    /**
+     * The aggregation of the queries to retrieve the latest query uses the IP or the user token to work efficiently.
+     * If the queries are made from your backend server, the IP will be the same for all of the queries.
+     * We're supporting the following HTTP header to forward the IP of your end-user to the engine, you just need to set it for each query.
+     *
+     * @see https://www.algolia.com/doc/faq/analytics/will-the-analytics-still-work-if-i-perform-the-search-through-my-backend
+     * @param string $ip
+     */
+    public function setForwardedFor($ip) {
+        $this->context->setForwardedFor($ip);
+    }
+
+    /**
+     * It's possible to use the following token to track users that have the same IP or to track users that use different devices
+     *
+     * @see https://www.algolia.com/doc/faq/analytics/will-the-analytics-still-work-if-i-perform-the-search-through-my-backend
+     * @param string $token
+     */
+    public function setAlgoliaUserToken($token) {
+        $this->context->setAlgoliaUserToken($token);
+    }
+
     /*
      * Disable IP rate limit enabled with enableRateLimitForward() function
      */
@@ -482,6 +504,7 @@ class Client {
                     'X-Algolia-Application-Id: ' . $context->applicationID,
                     'X-Algolia-API-Key: ' . $context->adminAPIKey,
                     'X-Forwarded-For: ' . $context->endUserIP,
+                    'X-Algolia-UserToken: ' . $context->algoliaUserToken,
                     'X-Forwarded-API-Key: ' . $context->rateLimitAPIKey,
                     'Content-type: application/json'
                     ), $context->headers));

--- a/src/AlgoliaSearch/ClientContext.php
+++ b/src/AlgoliaSearch/ClientContext.php
@@ -35,6 +35,8 @@ class ClientContext {
     public $writeHostsArray;
     public $curlMHandle;
     public $adminAPIKey;
+    public $endUserIP;
+    public $algoliaUserToken;
     public $connectTimeout;
 
     function __construct($applicationID, $apiKey, $hostsArray) {
@@ -59,6 +61,7 @@ class ClientContext {
         $this->curlMHandle = NULL;
         $this->adminAPIKey = NULL;
         $this->endUserIP = NULL;
+        $this->algoliaUserToken = NULL;
         $this->rateLimitAPIKey = NULL;
         $this->headers = array();
     }
@@ -81,7 +84,15 @@ class ClientContext {
     public function releaseMHandle($curlHandle) {
         curl_multi_remove_handle($this->curlMHandle, $curlHandle);
     }
-    
+
+    public function setForwardedFor($ip) {
+        $this->endUserIP = $ip;
+    }
+
+    public function setAlgoliaUserToken($token) {
+        $this->algoliaUserToken = $token;
+    }
+
     public function setRateLimit($adminAPIKey, $endUserIP, $rateLimitAPIKey) {
         $this->adminAPIKey = $adminAPIKey;
         $this->endUserIP = $endUserIP;


### PR DESCRIPTION
Implements the functionality from: https://www.algolia.com/doc/faq/analytics/will-the-analytics-still-work-if-i-perform-the-search-through-my-backend
fixes https://github.com/algolia/algoliasearch-client-php/issues/44

I haven't added tests since I cant configure them to run locally...