### PR TITLE
PHP7 Removed "split" Function

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -322,7 +322,7 @@ class Index {
       }
 
       if (gettype($disjunctive_facets) == "string") {
-        $disjunctive_facets = split(",", $disjunctive_facets);
+        $disjunctive_facets = explode(",", $disjunctive_facets);
       }
 
       $disjunctive_refinements = array();


### PR DESCRIPTION
Changed split to explode() as per PHP7 spec.