### PR TITLE
Fix custom headers

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -806,7 +806,7 @@ class Client
         //curl_setopt($curlHandle, CURLOPT_VERBOSE, true);
         $curlHeaders = [];
         foreach ($context->headers as $key => $value) {
-            array_push($curlHeaders, $key . ": " . $value);
+            $curlHeaders[] = $key . ": " . $value;
         }
         if ($context->adminAPIKey == null) {
             curl_setopt($curlHandle, CURLOPT_HTTPHEADER, array_merge([

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -804,12 +804,16 @@ class Client
         }
 
         //curl_setopt($curlHandle, CURLOPT_VERBOSE, true);
+        $curlHeaders = [];
+        foreach ($context->headers as $key => $value) {
+            array_push($curlHeaders, $key . ": " . $value);
+        }
         if ($context->adminAPIKey == null) {
             curl_setopt($curlHandle, CURLOPT_HTTPHEADER, array_merge([
                         'X-Algolia-Application-Id: '.$context->applicationID,
                         'X-Algolia-API-Key: '.$context->apiKey,
                         'Content-type: application/json',
-                        ], $context->headers));
+                        ], $curlHeaders));
         } else {
             curl_setopt($curlHandle, CURLOPT_HTTPHEADER, array_merge([
                     'X-Algolia-Application-Id: '.$context->applicationID,
@@ -818,7 +822,7 @@ class Client
                     'X-Algolia-UserToken: '.$context->algoliaUserToken,
                     'X-Forwarded-API-Key: '.$context->rateLimitAPIKey,
                     'Content-type: application/json',
-                    ], $context->headers));
+                    ], $curlHeaders));
         }
 
         curl_setopt($curlHandle, CURLOPT_USERAGENT, 'Algolia for PHP '.Version::get());


### PR DESCRIPTION
With the current code, the custom headers were always ignored because of the wrong format generated by the array_merge:

    0 => string 'X-Algolia-Application-Id: ME'
    1 => string 'X-Algolia-API-Key: TOP-SECRET'
    2 => string 'Content-type: application/json'
    'X-Forwarded-For' => string '159.253.242.85'

But in the documentation of curl it's written that only array are allowed, the associative **keyStr => val** array are not allowed.

> 	An array of HTTP header fields to set, in the format array('Content-type: text/plain', 'Content-length: 100')
