### PR TITLE
Check if cURL multi handles are valid resources instead of just null

### DIFF
--- a/src/AlgoliaSearch/ClientContext.php
+++ b/src/AlgoliaSearch/ClientContext.php
@@ -174,7 +174,7 @@ class ClientContext
      */
     public function __destruct()
     {
-        if ($this->curlMHandle != null) {
+        if (is_resource($this->curlMHandle)) {
             curl_multi_close($this->curlMHandle);
         }
     }
@@ -186,7 +186,7 @@ class ClientContext
      */
     public function getMHandle($curlHandle)
     {
-        if ($this->curlMHandle == null) {
+        if (!is_resource($this->curlMHandle)) {
             $this->curlMHandle = curl_multi_init();
         }
         curl_multi_add_handle($this->curlMHandle, $curlHandle);


### PR DESCRIPTION
### Problem

cURL multi handles are sometimes closed automatically by PHP during the shutdown process when using the Algolia client. The handle becomes invalid but is not set to `null` which causes warnings when trying to use or close an invalid handle. This issue would probably only happen if you were using the Algolia client to perform indexing operations after the response has already been sent back to the browser.
### Reproduction

Here's a quick REPL example illustrating how this can happen:

```
php > $mh = curl_multi_init();
php > var_dump(is_null($mh));
bool(false)
php > var_dump(is_resource($mh));
bool(true)
php > // looks good so far
php > // simulate handle being closed randomly, i.e. automatically by PHP in the shutdown sequence
php > curl_multi_close($mh);
php > var_dump(is_null($mh));
bool(false)
php > var_dump(is_resource($mh));
bool(false)
php > // the handle is not a valid resource but also not null
php > // accessing it will generate warnings
php > curl_multi_close($mh);
PHP Warning:  curl_multi_close(): 1 is not a valid cURL Multi Handle resource in php shell code on line 1
PHP Stack trace:
PHP   1. {main}() php shell code:0
PHP   2. curl_multi_close() php shell code:1

Warning: curl_multi_close(): 1 is not a valid cURL Multi Handle resource in php shell code on line 1

Call Stack:
  175.8021     222784   1. {main}() php shell code:0
  175.8021     222832   2. curl_multi_close() php shell code:1

php > 
```
### Solution

`is_resource()` should be used when deciding to open or close cURL multi handle resources because it's a more stringent check than checking for `null`. In addition to checking the variable has the `resource` type, it will also check if the resource is valid (see [PHP docs on is_resource](http://php.net/manual/en/function.is-resource.php)).
