### PR TITLE
Implement statefull connection retry strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
-sudo: false
+matrix:
+  include:
+    - php: 5.3
+    - php: 5.4
+      dist: trusty
+      sudo: required
+    - php: 5.5
+      dist: trusty
+      sudo: required
+    - php: 5.6
+      dist: trusty
+      sudo: required
+    - php: 7.0
+      dist: trusty
+      sudo: required
+    - php: hhvm
+      dist: trusty
+      sudo: required
 
 cache:
   directories:

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -110,7 +110,7 @@ class Client
     }
 
     /**
-     * Change the default connect timeout of 2s to a custom value
+     * Change the default connect timeout of 1s to a custom value
      * (only useful if your server has a very slow connectivity to Algolia backend).
      *
      * @param int $connectTimeout the connection timeout
@@ -743,6 +743,9 @@ class Client
                 throw $e;
             } catch (\Exception $e) {
                 $exceptions[$host] = $e->getMessage();
+                if ($context instanceof ClientContext) {
+                    $context->rotateHosts($host);
+                }
             }
         }
         throw new AlgoliaException('Hosts unreachable: '.implode(',', $exceptions));

--- a/tests/AlgoliaSearch/Tests/AccessTest.php
+++ b/tests/AlgoliaSearch/Tests/AccessTest.php
@@ -32,4 +32,26 @@ class AccessTest extends AlgoliaSearchTestCase
 
         $client->isAlive();
     }
+
+    public function testStatefullRetryStrategy()
+    {
+        if (version_compare(phpversion(), '5.4', '<')) {
+            $this->markTestSkipped("No way to test statefull retry strategy in Travis for PHP 5.3.");
+        }
+
+        $client = new Client(
+            getenv('ALGOLIA_APPLICATION_ID'),
+            getenv('ALGOLIA_API_KEY'),
+            array(
+                getenv('ALGOLIA_APPLICATION_ID') . '.algolia.biz', // Unresolvable.
+                getenv('ALGOLIA_APPLICATION_ID') . '.algolia.net',
+            )
+        );
+        $start = microtime(true);
+        for ($i = 0; $i < 10; $i++) {
+            $client->isAlive();
+        }
+        $processingTime = microtime(true) - $start;
+        $this->assertLessThan(5, $processingTime);
+    }
 }


### PR DESCRIPTION
Resolves: #181

This PR will rotate the hosts array at each failed connection attempt. 
ClientContext holds the state and the Client simply ask for a rotation by passing the "justUnresolvable" host as argument.

**Shared state between different instances of the Client:**
Given the current design of the Client, sharing state between different Client instances is not feasable. Also I don't think it is a big issue because most of the time, there will only be one instance of the client per PHP thread.

If for some reason a user wants to share the state between multiple instances of a the client, he could simply override the ClientContext on all the Client.
**Shared state between different PHP processes**
In PHP processes don't share state between them, every process spawning is an attempt to recover connection to the main host. In a future version of the API Client, we could create an abstraction around the state to share it via storage layer (ideally in memory k/v store), but for now this will be overkill and very messy to implement.

Let me know your thoughts @maxiloc @JanPetr @redox 