### PR TITLE
Keep state between processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
     - composer install
 
 script:
-  - phpunit --debug -c phpunit.xml.dist
+  - vendor/bin/phpunit --debug -c phpunit.xml.dist
 
 env:
   global:

--- a/algoliasearch.php
+++ b/algoliasearch.php
@@ -33,3 +33,6 @@ require_once 'src/AlgoliaSearch/PlacesIndex.php';
 require_once 'src/AlgoliaSearch/SynonymType.php';
 require_once 'src/AlgoliaSearch/Version.php';
 require_once 'src/AlgoliaSearch/Json.php';
+require_once 'src/AlgoliaSearch/FailingHostsCache.php';
+require_once 'src/AlgoliaSearch/FileFailingHostsCache.php';
+require_once 'src/AlgoliaSearch/InMemoryFailingHostsCache.php';

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -37,6 +37,7 @@ class Client
     const CAINFO = 'cainfo';
     const CURLOPT = 'curloptions';
     const PLACES_ENABLED = 'placesEnabled';
+    const FAILING_HOSTS_CACHE = 'failingHostsCache';
 
     /**
      * @var ClientContext
@@ -94,12 +95,18 @@ class Client
                 case self::PLACES_ENABLED:
                     $this->placesEnabled = (bool) $value;
                     break;
+                case self::FAILING_HOSTS_CACHE:
+                    if (! $value instanceof FailingHostsCache) {
+                        throw new \InvalidArgumentException('failingHostsCache must be an instance of \AlgoliaSearch\FailingHostsCache.');
+                    }
+                    break;
                 default:
                     throw new \Exception('Unknown option: '.$option);
             }
         }
 
-        $this->context = new ClientContext($applicationID, $apiKey, $hostsArray, $this->placesEnabled);
+        $failingHostsCache = isset($options[self::FAILING_HOSTS_CACHE]) ? $options[self::FAILING_HOSTS_CACHE] : null;
+        $this->context = new ClientContext($applicationID, $apiKey, $hostsArray, $this->placesEnabled, $failingHostsCache);
     }
 
     /**

--- a/src/AlgoliaSearch/FailingHostsCache.php
+++ b/src/AlgoliaSearch/FailingHostsCache.php
@@ -1,0 +1,23 @@
+<?php
+namespace AlgoliaSearch;
+
+interface FailingHostsCache
+{
+    /**
+     * @param string $host
+     */
+    public function addFailingHost($host);
+
+    /**
+     * Get failing hosts from cache. This method should also handle cache invalidation if required.
+     * The TTL of the failed hosts cache should be 5 minutes.
+     *
+     * @return array
+     */
+    public function getFailingHosts();
+
+    /**
+     * Invalidates the cache.
+     */
+    public function flushFailingHostsCache();
+}

--- a/src/AlgoliaSearch/FileFailingHostsCache.php
+++ b/src/AlgoliaSearch/FileFailingHostsCache.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace AlgoliaSearch;
+
+class FileFailingHostsCache implements FailingHostsCache
+{
+    /**
+     * Timestamp key used in the JSON representation.
+     */
+    const TIMESTAMP = 'timestamp';
+
+    /**
+     * Failing hosts key used in the JSON representation.
+     */
+    const FAILING_HOSTS = 'failing_hosts';
+
+    /**
+     * @var string
+     */
+    private $failingHostsCacheFile;
+
+    /**
+     * @var int
+     */
+    private $ttl;
+
+    /**
+     * @param int|null    $ttl The time to live of the cache in seconds.
+     * @param string|null $file
+     *
+     */
+    public function __construct($ttl = null, $file = null)
+    {
+        if ($file === null) {
+            $this->failingHostsCacheFile = $this->getDefaultCacheFile();
+        } else {
+            $this->failingHostsCacheFile = (string) $file;
+        }
+
+        $this->assertCacheFileIsValid($this->failingHostsCacheFile);
+
+        if ($ttl === null) {
+            $ttl = 60 * 5; // 5 minutes
+        }
+
+        $this->ttl = (int) $ttl;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTtl()
+    {
+        return $this->ttl;
+    }
+
+    /**
+     * @param $file
+     */
+    private function assertCacheFileIsValid($file)
+    {
+        $fileDirectory = dirname($file);
+
+        if (! is_writable($fileDirectory)) {
+            throw new \RuntimeException(sprintf('Cache file directory "%s" is not writable.', $fileDirectory));
+        }
+
+        if (! file_exists($file)) {
+            // The dir being writable, the file will be created when needed.
+            return;
+        }
+
+        if (! is_readable($file)) {
+            throw new \RuntimeException(sprintf('Cache file "%s" is not readable.', $file));
+        }
+
+        if (! is_writable($file)) {
+            throw new \RuntimeException(sprintf('Cache file "%s" is not writable.', $file));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function getDefaultCacheFile()
+    {
+        return sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'algolia-failing-hosts';
+    }
+
+    /**
+     * @param string $host
+     */
+    public function addFailingHost($host)
+    {
+        $cache = $this->loadFailingHostsCacheFromDisk();
+
+        if (isset($cache[self::TIMESTAMP]) && isset($cache[self::FAILING_HOSTS])) {
+            // Update failing hosts cache.
+            // Here we don't take care of invalidating. We do that on retrieval.
+            if (!in_array($host, $cache[self::FAILING_HOSTS])) {
+                $cache[self::FAILING_HOSTS][] = $host;
+                $this->writeFailingHostsCacheFile($cache);
+            }
+        } else {
+            $cache[self::TIMESTAMP] = time();
+            $cache[self::FAILING_HOSTS] = array($host);
+            $this->writeFailingHostsCacheFile($cache);
+        }
+    }
+
+    /**
+     * Get failing hosts from cache. This method should also handle cache invalidation if required.
+     * The TTL of the failed hosts cache should be 5mins.
+     *
+     * @return array
+     */
+    public function getFailingHosts()
+    {
+        $cache = $this->loadFailingHostsCacheFromDisk();
+
+        return isset($cache[self::FAILING_HOSTS]) ? $cache[self::FAILING_HOSTS] : array();
+    }
+
+    /**
+     * Removes the file storing the failing hosts.
+     */
+    public function flushFailingHostsCache()
+    {
+        if (file_exists($this->failingHostsCacheFile)) {
+            unlink($this->failingHostsCacheFile);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    private function loadFailingHostsCacheFromDisk()
+    {
+        if (! file_exists($this->failingHostsCacheFile)) {
+            return array();
+        }
+
+        $json = file_get_contents($this->failingHostsCacheFile);
+        if ($json === false) {
+            return array();
+        }
+
+        $data = json_decode($json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return array();
+        }
+
+        // Some basic checks.
+        if (
+            !isset($data[self::TIMESTAMP])
+            || !isset($data[self::FAILING_HOSTS])
+            || !is_int($data[self::TIMESTAMP])
+            || !is_array($data[self::FAILING_HOSTS])
+        ) {
+            return array();
+        }
+
+        // Validate the hosts array.
+        foreach ($data[self::FAILING_HOSTS] as $host) {
+            if (!is_string($host)) {
+                return array();
+            }
+        }
+
+        $elapsed = time() - $data[self::TIMESTAMP]; // Number of seconds elapsed.
+
+        if ($elapsed > $this->ttl) {
+            $this->flushFailingHostsCache();
+
+            return array();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     */
+    private function writeFailingHostsCacheFile(array $data)
+    {
+        $json = json_encode($data);
+        if ($json !== false) {
+            file_put_contents($this->failingHostsCacheFile, $json);
+        }
+    }
+}

--- a/src/AlgoliaSearch/InMemoryFailingHostsCache.php
+++ b/src/AlgoliaSearch/InMemoryFailingHostsCache.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AlgoliaSearch;
+
+class InMemoryFailingHostsCache implements FailingHostsCache
+{
+
+    /**
+     * @var array
+     */
+    private static $failingHosts = array();
+
+    /**
+     * @var int
+     */
+    private static $timestamp;
+
+    /**
+     * @var int
+     */
+    private $ttl;
+
+    /**
+     * @param int|null $ttl The time to live of the cache in seconds.
+     */
+    public function __construct($ttl = null)
+    {
+        if ($ttl === null) {
+            $ttl = 60 * 5; // 5 minutes
+        }
+        
+        $this->ttl = (int) $ttl;
+    }
+
+
+    /**
+     * @param string $host
+     */
+    public function addFailingHost($host)
+    {
+        if (! in_array($host, self::$failingHosts)) {
+            // Keep a local cache of failed hosts in case the file based strategy doesn't work out.
+            self::$failingHosts[] = $host;
+
+            if (self::$timestamp === null) {
+                self::$timestamp = time();
+            }
+        }
+    }
+
+    /**
+     * Get failing hosts from cache. This method should also handle cache invalidation if required.
+     * The TTL of the failed hosts cache should be 5mins.
+     *
+     * @return array
+     */
+    public function getFailingHosts()
+    {
+        if (self::$timestamp === null) {
+            return self::$failingHosts;
+        }
+
+        $elapsed = time() - self::$timestamp;
+        if ($elapsed > $this->ttl) {
+            $this->flushFailingHostsCache();
+        }
+
+        return self::$failingHosts;
+    }
+    
+    public function flushFailingHostsCache()
+    {
+        self::$failingHosts = array();
+        self::$timestamp = null;
+    }
+}

--- a/tests/AlgoliaSearch/Tests/ClientTest.php
+++ b/tests/AlgoliaSearch/Tests/ClientTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+use AlgoliaSearch\Client;
+use AlgoliaSearch\FileFailingHostsCache;
+use AlgoliaSearch\InMemoryFailingHostsCache;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testEnsuresFailingHostsCacheIsOfCorrectType()
+    {
+        new Client('whatever', 'whatever', null, array(
+            Client::FAILING_HOSTS_CACHE => 'incorrect_type',
+        ));
+    }
+
+    public function testShouldForwardFailingHostsCacheToClientContext()
+    {
+        $cache = new InMemoryFailingHostsCache();
+
+        $client = new Client('whatever', 'whatever', null, array(
+            Client::FAILING_HOSTS_CACHE => $cache,
+        ));
+
+        $this->assertSame($cache, $client->getContext()->getFailingHostsCache());
+
+        $cache = new FileFailingHostsCache();
+
+        $client = new Client('whatever', 'whatever', null, array(
+            Client::FAILING_HOSTS_CACHE => $cache,
+        ));
+
+        $this->assertSame($cache, $client->getContext()->getFailingHostsCache());
+    }
+
+    public function testCanLetClientContextChooseFailingHostsCache()
+    {
+        $client = new Client('whatever', 'whatever');
+        $this->assertInstanceOf('\AlgoliaSearch\FailingHostsCache', $client->getContext()->getFailingHostsCache());
+    }
+}

--- a/tests/AlgoliaSearch/Tests/FailingHostsCacheTestCase.php
+++ b/tests/AlgoliaSearch/Tests/FailingHostsCacheTestCase.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+use AlgoliaSearch\FailingHostsCache;
+
+abstract class FailingHostsCacheTestCase extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldDeduplicateFailingHosts()
+    {
+        $cache = $this->getNewCleanCacheInstance();
+
+        $cache->addFailingHost('host1.com');
+        $cache->addFailingHost('host2.com');
+        $cache->addFailingHost('host1.com');
+        $cache->addFailingHost('host3.com');
+        $cache->addFailingHost('host2.com');
+
+        $this->assertEquals(array('host1.com', 'host2.com', 'host3.com'), $cache->getFailingHosts());
+    }
+
+    public function testCacheCanBeInvalidated()
+    {
+        $cache = $this->getNewCacheInstance();
+        $cache->addFailingHost('host1.com');
+
+        $cache->flushFailingHostsCache();
+
+        $this->assertEquals(array(), $cache->getFailingHosts());
+    }
+
+    /**
+     * @depends testCacheCanBeInvalidated
+     */
+    public function testShouldShareFailingHostsBetweenInstances()
+    {
+        $cache = $this->getNewCleanCacheInstance();
+        
+        $cache->addFailingHost('host1.com');
+
+        $cache2 = $this->getNewCacheInstance();
+        $cache2->addFailingHost('host2.com');
+        
+        // The 2 instances should have the same state.
+        $this->assertEquals(array('host1.com', 'host2.com'), $cache->getFailingHosts());
+        $this->assertEquals(array('host1.com', 'host2.com'), $cache2->getFailingHosts());
+        
+        // Clean the state.
+        $cache2->flushFailingHostsCache();
+
+        // Ensure state is cleaned in both instances.
+        $this->assertEquals(array(), $cache->getFailingHosts());
+        $this->assertEquals(array(), $cache2->getFailingHosts());
+    }
+
+    public function testShouldInvalidateWhenTtlIsReached()
+    {
+        $cache = $this->getNewCleanCacheInstance();
+
+        $cache->addFailingHost('host1.com');
+
+        $this->assertEquals(array('host1.com'), $cache->getFailingHosts());
+
+        sleep(3);
+
+        $this->assertEquals(array(), $cache->getFailingHosts());
+    }
+
+    /**
+     * @param int $ttl
+     *
+     * @return FailingHostsCache
+     */
+    protected function getNewCleanCacheInstance($ttl = 2)
+    {
+        $cache = $this->getNewCacheInstance($ttl);
+        $cache->flushFailingHostsCache();
+
+        return $cache;
+    }
+
+    /**
+     * @param int $ttl
+     *
+     * @return FailingHostsCache
+     */
+    abstract public function getNewCacheInstance($ttl = 2);
+}

--- a/tests/AlgoliaSearch/Tests/FileFailingHostsCacheTest.php
+++ b/tests/AlgoliaSearch/Tests/FileFailingHostsCacheTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+use AlgoliaSearch\FileFailingHostsCache;
+
+class FileFailingHostsCacheTest extends FailingHostsCacheTestCase
+{
+    public function testShouldThrowAnExceptionIfCacheDirectoryIsNotWritable()
+    {
+        $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
+        $cacheFile = $dir . DIRECTORY_SEPARATOR . 'cache_file';
+        @unlink($cacheFile);
+        @rmdir($dir);
+        mkdir($dir, 0555);
+
+        $this->setExpectedException('\RuntimeException', 'Cache file directory "' . $dir . '" is not writable.');
+
+        new FileFailingHostsCache(5, $cacheFile);
+    }
+
+    public function testShouldThrowAnExceptionIfCacheFileExistsButIsNotReadable()
+    {
+        $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
+        $cacheFile = $dir . DIRECTORY_SEPARATOR . 'cache_file';
+        @unlink($cacheFile);
+        @rmdir($dir);
+        mkdir($dir, 0777);
+        touch($cacheFile);
+        chmod($cacheFile, 0222); // not readable.
+
+        $this->setExpectedException('\RuntimeException', 'Cache file "' . $cacheFile . '" is not readable.');
+
+        new FileFailingHostsCache(5, $cacheFile);
+    }
+
+    public function testShouldThrowAnExceptionIfCacheFileExistsButIsNotWritable()
+    {
+        $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
+        $cacheFile = $dir . DIRECTORY_SEPARATOR . 'cache_file';
+        @unlink($cacheFile);
+        @rmdir($dir);
+        mkdir($dir, 0777);
+        touch($cacheFile);
+        chmod($cacheFile, 0555); // not writable.
+
+        $this->setExpectedException('\RuntimeException', 'Cache file "' . $cacheFile . '" is not writable.');
+
+        new FileFailingHostsCache(5, $cacheFile);
+    }
+
+    public function testShouldGracefullyHandleInvalidJsonInCacheFile()
+    {
+        $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
+        $cacheFile = $dir . DIRECTORY_SEPARATOR . 'cache_file';
+        @unlink($cacheFile);
+        @rmdir($dir);
+        mkdir($dir, 0777);
+        file_put_contents($cacheFile, '{broken json');
+        chmod($cacheFile, 0777); // not writable.
+
+        $cache = new FileFailingHostsCache(5, $cacheFile);
+        $hosts = $cache->getFailingHosts();
+        $this->assertEquals(array(), $hosts);
+    }
+
+    public function testThatDefaultTtlIs5Minutes()
+    {
+        $cache = new FileFailingHostsCache();
+        $this->assertEquals(60*5, $cache->getTtl());
+    }
+
+    public function testThatTtlCanBeOverridden()
+    {
+        $cache = new FileFailingHostsCache(15);
+        $this->assertEquals(15, $cache->getTtl());
+    }
+
+    /**
+     * @param int $ttl
+     *
+     * @return FailingHostsCache
+     */
+    public function getNewCacheInstance($ttl = 2)
+    {
+        return new FileFailingHostsCache($ttl);
+    }
+}

--- a/tests/AlgoliaSearch/Tests/InMemoryFailingHostsCacheTest.php
+++ b/tests/AlgoliaSearch/Tests/InMemoryFailingHostsCacheTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+use AlgoliaSearch\InMemoryFailingHostsCache;
+
+class InMemoryFailingHostsCacheTest extends FailingHostsCacheTestCase
+{
+    /**
+     * @param int $ttl
+     *
+     * @return FailingHostsCache
+     */
+    public function getNewCacheInstance($ttl = 2)
+    {
+        return new InMemoryFailingHostsCache($ttl);
+    }
+}

--- a/tests/AlgoliaSearch/Tests/global_functions_stubs.php
+++ b/tests/AlgoliaSearch/Tests/global_functions_stubs.php
@@ -1,0 +1,15 @@
+<?php
+namespace AlgoliaSearch;
+
+$make_is_writable_fail = false;
+
+function is_writable($filename)
+{
+    global $make_is_writable_fail;
+
+    if (true === $make_is_writable_fail) {
+        return false;
+    }
+
+    return \is_writeable($filename);
+}

--- a/tests/benchmark.php
+++ b/tests/benchmark.php
@@ -1,0 +1,53 @@
+<?php
+require 'vendor/autoload.php';
+
+
+$fileBasedCache = new \AlgoliaSearch\FileFailingHostsCache();
+$fileBasedCache->flushFailingHostsCache();
+$client = new \AlgoliaSearch\Client(
+	getenv('ALGOLIA_APPLICATION_ID'),
+	getenv('ALGOLIA_API_KEY'),
+	array(
+		'APP_ID_1' . '.algolia.biz', // .biz will always fail to resolve
+		getenv('ALGOLIA_APPLICATION_ID') . '.algolia.biz',
+		getenv('ALGOLIA_APPLICATION_ID') . '.algolia.net'
+	),
+	array(
+		\AlgoliaSearch\Client::FAILING_HOSTS_CACHE => $fileBasedCache
+	)
+);
+
+$start = microtime(true);
+$client->listIndexes();
+$end = round((microtime(true) - $start)*1000);
+echo '[FileFailingHostsCache] First call processing time:' . $end . PHP_EOL;
+
+
+$start = microtime(true);
+$client->listIndexes();
+$end = round((microtime(true) - $start)*1000);
+echo '[FileFailingHostsCache] Second call processing time:' . $end . PHP_EOL;
+
+$client = new \AlgoliaSearch\Client(
+	getenv('ALGOLIA_APPLICATION_ID'),
+	getenv('ALGOLIA_API_KEY'),
+	array(
+		'APP_ID_1' . '.algolia.biz', // .biz will always fail to resolve
+		getenv('ALGOLIA_APPLICATION_ID') . '.algolia.biz',
+		getenv('ALGOLIA_APPLICATION_ID') . '.algolia.net'
+	),
+	array(
+		\AlgoliaSearch\Client::FAILING_HOSTS_CACHE => new \AlgoliaSearch\InMemoryFailingHostsCache()
+	)
+);
+
+$start = microtime(true);
+$client->listIndexes();
+$end = round((microtime(true) - $start)*1000);
+echo '[InMemoryFailingHostsCache] First call processing time:' . $end . PHP_EOL;
+
+
+$start = microtime(true);
+$client->listIndexes();
+$end = round((microtime(true) - $start)*1000);
+echo '[InMemoryFailingHostsCache] Second call processing time:' . $end . PHP_EOL;


### PR DESCRIPTION
We abstracted an interface for the failed hosts retrieval so that users can easily choose their caching strategy based on what is best according to their environment.

By default we push the new File Based cache strategy, but if the tmp directory is not writable, we fallback to the in memory strategy.

User can provide an implementation of FailingHostsCache as a replacement of this strategy.

Because of the current design of the Client, the FailingHostsCache implementation needs to be provided at Client initialization because that is where the ClientContext is instantiated and during that instantiation we need to rotate the hosts.

Regarding the BC static to non static, given it has only been available in 1 version and was only used internally + wasn't even called statically, I think we are safe doing the change.

TODO:
- [x] Unit tests
- [x] Choose if we push the file based cache by default or if we keep the in memory strategy
- [x] Implement in memory cache invalidation for long running PHP processes  > 5min
- [x] See what we do about the static to public method signature of addFailingHost (BC) that was only introduced in last version