### PR TITLE
Autoload tests only on dev environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
     },
     "autoload": {
         "psr-0": {
-            "AlgoliaSearch": "src/",
+            "AlgoliaSearch": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
             "AlgoliaSearch\\Tests": "tests/"
         }
     }


### PR DESCRIPTION
Composer offers a separate autoload property for development environment. This is ideal to load tests if they are in a separate namespace, especially if the tests aren't distributed to the production environments (as [specified](https://github.com/algolia/algoliasearch-client-php/blob/master/.gitattributes#L4) in the `.gitattributes` file).

We're running a couple automated scripts that rely on having all files that need to be autoloaded, to be present. Not having the tests directory, but having it in the autoloader makes this rather hard to do (as in: need to write exceptions to our scripts, for every single package doing this).

There are no downsides to only loading tests in development environment, so this change would be greatly appreciated.