### PR TITLE
Autoload tests only on dev environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
     },
     "autoload": {
         "psr-0": {
-            "AlgoliaSearch": "src/",
+            "AlgoliaSearch": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
             "AlgoliaSearch\\Tests": "tests/"
         }
     }


### PR DESCRIPTION
Composer offers a separate autoload property for development environment. This is ideal to load tests if they are in a separate namespace, especially if the tests aren't distributed to the production environments (as specified in the `.gitattributes` file).