### PR TITLE
Introduce SynonymsBrowser class

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1509,9 +1509,9 @@ class Index
         );
     }
 
-    public function exportSynonyms(array $synonymType = array(), $batchSize = 500)
+    public function exportSynonyms($batchSize = 500)
     {
-        return new SynonymBrowser($this, $synonymType, 0, $batchSize);
+        return new SynonymBrowser($this, $batchSize);
     }
 
     /**

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1509,7 +1509,7 @@ class Index
         );
     }
 
-    public function exportSynonyms($batchSize = 500)
+    public function initSynonymBrowser($batchSize = 1000)
     {
         return new SynonymBrowser($this, $batchSize);
     }

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1509,6 +1509,11 @@ class Index
         );
     }
 
+    public function exportSynonyms(array $synonymType = array(), $batchSize = 500)
+    {
+        return new SynonymBrowser($this, $synonymType, 0, $batchSize);
+    }
+
     /**
      * @deprecated Please use searchForFacetValues instead
      * @param $facetName

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace AlgoliaSearch;
+
+
+class SynonymBrowser implements \Iterator
+{
+    /**
+     * @var Index
+     */
+    private $index;
+
+    /**
+     * @var array Used to filter the type of synonyms you want to export
+     */
+    private $synonymType;
+
+    /**
+     * @var int Zero-based page number
+     */
+    private $page;
+
+    /**
+     * @var int Number of results to return from each call to Algolia
+     */
+    private $hitsPerPage;
+
+    /**
+     * @var int Position in the current paginated result batch
+     */
+    private $position;
+
+    /**
+     * @var array Formatted current element
+     */
+    private $hit;
+
+    /**
+     * @var array Response from the last Algolia API call,
+     * this contains the results for the current page.
+     */
+    private $response;
+
+    /**
+     * SynonymBrowser constructor.
+     * @param Index $index
+     * @param array $synonymType
+     * @param int $page
+     * @param int $hitsPerPage
+     */
+    public function __construct($index, array $synonymType = array(), $page = 0, $hitsPerPage = 500)
+    {
+        $this->index = $index;
+        $this->synonymType = $synonymType;
+        $this->page = $page;
+        $this->hitsPerPage = $hitsPerPage;
+
+        $this->position = 0;
+
+        $this->doQuery($page);
+    }
+
+    /**
+     * Return the current element
+     * @return mixed Can return any type.
+     */
+    public function current()
+    {
+        return $this->hit;
+    }
+
+    /**
+     * Move forward to next element
+     * @return void Any returned value is ignored.
+     */
+    public function next()
+    {
+        $this->position++;
+    }
+
+    /**
+     * Return the key of the current element
+     * @return mixed scalar on success, or null on failure.
+     */
+    public function key()
+    {
+        $key = $this->page * $this->hitsPerPage + $this->position;
+
+        return $key;
+
+    }
+
+    /**
+     * Checks if current position is valid. If the current position
+     * is not valid, we call Algolia' API to load more results
+     * until it's the last page.
+     *
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     */
+    public function valid()
+    {
+        if (isset($this->response['hits'][$this->position])) {
+            $this->hit = $this->formatHit($this->response['hits'][$this->position]);
+
+            return true;
+        }
+
+        // No more results and it was the last page
+        if (count($this->response['hits']) < $this->hitsPerPage) {
+            return false;
+        }
+
+        // No more results but still results in Algolia
+        // We call Algolia and loop back to this function
+        $this->doQuery($this->page + 1);
+
+        return $this->valid();
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     * @return void Any returned value is ignored.
+     */
+    public function rewind()
+    {
+        $this->page = 0;
+        $this->position = 0;
+        $this->hit = null;
+    }
+
+    /**
+     * Call Algolia' API to get new result batch
+     *
+     * @param $page Page number to call
+     */
+    private function doQuery($page)
+    {
+        $this->page = $page;
+        $this->position = 0;
+
+        $this->response = $this->index->searchSynonyms('', $this->synonymType, $page, $this->hitsPerPage);
+    }
+
+    /**
+     * The export method is using search internally, this method
+     * is used to clean the resuls, like remove the highlight
+     *
+     * @param array $hit
+     * @return array formatted synonym array
+     */
+    private function formatHit(array $hit)
+    {
+        unset($hit['_highlightResult']);
+
+        return $hit;
+    }
+}

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -33,8 +33,12 @@ class SynonymBrowser implements \Iterator
      */
     public function __construct(Index $index, $hitsPerPage = 1000)
     {
+        if ($hitsPerPage <= 0) {
+            throw new \InvalidArgumentException('Hits per page should be bigger than zero.');
+        }
+
         $this->index = $index;
-        $this->hitsPerPage = $hitsPerPage;
+        $this->hitsPerPage = (int) $hitsPerPage;
     }
 
     /**

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -66,10 +66,13 @@ class SynonymBrowser implements \Iterator
     {
         $this->position++;
 
+        if ($this->valid()) {
+            return;
+        }
+
         // If the end of the batch is reached but there are
-        // more results in Algolia, we get the next page
-        if (! isset($this->response['hits'][$this->position])
-            && count($this->response['hits']) >= $this->hitsPerPage) {
+        // more results in Algolia, we get the next page.
+        if (count($this->response['hits']) >= $this->hitsPerPage) {
             $this->page++;
             $this->fetchCurrentPageResults();
         }

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -126,7 +126,7 @@ class SynonymBrowser implements \Iterator
 
     /**
      * The export method is using search internally, this method
-     * is used to clean the resuls, like remove the highlight
+     * is used to clean the results, like remove the highlight
      *
      * @param array $hit
      * @return array formatted synonym array

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -11,11 +11,6 @@ class SynonymBrowser implements \Iterator
     private $index;
 
     /**
-     * @var array Used to filter the type of synonyms you want to export
-     */
-    private $synonymType;
-
-    /**
      * @var int Zero-based page number
      */
     private $page;
@@ -44,17 +39,14 @@ class SynonymBrowser implements \Iterator
     /**
      * SynonymBrowser constructor.
      * @param Index $index
-     * @param array $synonymType
-     * @param int $page
      * @param int $hitsPerPage
      */
-    public function __construct($index, array $synonymType = array(), $page = 0, $hitsPerPage = 500)
+    public function __construct($index, $hitsPerPage = 500)
     {
         $this->index = $index;
-        $this->synonymType = $synonymType;
-        $this->page = $page;
         $this->hitsPerPage = $hitsPerPage;
 
+        $this->page = 0;
         $this->position = 0;
 
         $this->doQuery($page);
@@ -62,7 +54,7 @@ class SynonymBrowser implements \Iterator
 
     /**
      * Return the current element
-     * @return mixed Can return any type.
+     * @return array
      */
     public function current()
     {
@@ -139,7 +131,7 @@ class SynonymBrowser implements \Iterator
         $this->page = $page;
         $this->position = 0;
 
-        $this->response = $this->index->searchSynonyms('', $this->synonymType, $page, $this->hitsPerPage);
+        $this->response = $this->index->searchSynonyms('', array(), $page, $this->hitsPerPage);
     }
 
     /**

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -70,7 +70,8 @@ class SynonymBrowser implements \Iterator
         // more results in Algolia, we get the next page
         if (! isset($this->response['hits'][$this->position])
             && count($this->response['hits']) >= $this->hitsPerPage) {
-            $this->doQuery($this->page + 1);
+            $this->page++;
+            $this->fetchCurrentPageResults();
         }
     }
 
@@ -108,7 +109,7 @@ class SynonymBrowser implements \Iterator
         $this->page = 0;
         $this->position = 0;
 
-        $this->doQuery($this->page);
+        $this->fetchCurrentPageResults();
     }
 
     /**
@@ -116,12 +117,10 @@ class SynonymBrowser implements \Iterator
      *
      * @param $page Page number to call
      */
-    private function doQuery($page)
+    private function fetchCurrentPageResults()
     {
-        $this->page = $page;
         $this->position = 0;
-
-        $this->response = $this->index->searchSynonyms('', array(), $page, $this->hitsPerPage);
+        $this->response = $this->index->searchSynonyms('', array(), $this->page, $this->hitsPerPage);
     }
 
     /**

--- a/src/AlgoliaSearch/SynonymBrowser.php
+++ b/src/AlgoliaSearch/SynonymBrowser.php
@@ -51,6 +51,10 @@ class SynonymBrowser implements \Iterator
      */
     public function current()
     {
+        if ($this->response === null) {
+            $this->rewind();
+        }
+
         return $this->formatHit($this->response['hits'][$this->position]);
     }
 

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -5,6 +5,7 @@ namespace AlgoliaSearch\Tests;
 use AlgoliaSearch\AlgoliaException;
 use AlgoliaSearch\Client;
 use AlgoliaSearch\Index;
+use AlgoliaSearch\SynonymBrowser;
 
 class SynonymsExportTest extends AlgoliaSearchTestCase
 {
@@ -36,6 +37,14 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         } catch (AlgoliaException $e) {
             // not fatal
         }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testShouldRejectInvalidHitsPerPage()
+    {
+        new SynonymBrowser($this->index, 0);
     }
 
     public function testSynonymsExport()

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -14,19 +14,19 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
     /** @var Index */
     private $index;
 
+    private $indexName = 'test-synonym-export-php';
+
     protected function setUp()
     {
         $this->client = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'));
-        $this->index = $this->client->initIndex($this->safe_name('test-synonym-export-php'));
+        $this->index = $this->client->initIndex($this->indexName);
+        $this->index->addObject(array('note' => 'Create index in Algolia'));
 
         try {
-            $this->index->clearIndex();
+            $this->index->clearSynonyms();
         } catch (AlgoliaException $e) {
             // not fatal
         }
-
-        $res = $this->index->addObject(array('name' => '589 Howard St., San Francisco'));
-        $this->index->waitTask($res['taskID'], 0.1);
 
         $res = $this->index->batchSynonyms(array(
             array(
@@ -65,7 +65,7 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $i = 0;
         $exported = array();
 
-        $browser = $this->index->exportSynonyms(2);
+        $browser = $this->index->initSynonymBrowser(2);
 
         foreach ($browser as $k => $synonym) {
             // Check if the key is correct, not related to pagination

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -23,7 +23,7 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $this->index->addObject(array('note' => 'Create index in Algolia'));
 
         try {
-            $this->index->clearSynonyms();
+            $this->clearSynonyms();
         } catch (AlgoliaException $e) {
             // not fatal
         }
@@ -66,16 +66,29 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $exported = array();
 
         $browser = $this->index->initSynonymBrowser(2);
+        $lastObjectID = '';
 
         foreach ($browser as $k => $synonym) {
             // Check if the key is correct, not related to pagination
             $this->assertEquals($i, $k, 'The synonymsExporter returned incorrect keys.');
-            $i++;
+            $this->assertArrayHasKey('objectID', $synonym, 'objectID is missing in exported synonym');
+            $this->assertNotEquals($lastObjectID, $synonym['objectID']);
 
+            $i++;
+            $lastObjectID = $synonym['objectID'];
             $exported[] = $synonym;
         }
 
         $this->assertFalse(isset($synonym['_highlightResult']), 'Synonyms were not formatted properly.');
         $this->assertEquals(3, count($exported), 'Some synonyms were not exported.');
+
+        $this->clearSynonyms();
+        $this->index->batchSynonyms($exported);
+    }
+
+    private function clearSynonyms()
+    {
+        $res = $this->index->clearSynonyms();
+        $this->index->waitTask($res['taskID'], 0.1);
     }
 }

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -27,7 +27,19 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         } catch (AlgoliaException $e) {
             // not fatal
         }
+    }
 
+    protected function tearDown()
+    {
+        try {
+            $this->client->deleteIndex($this->indexName);
+        } catch (AlgoliaException $e) {
+            // not fatal
+        }
+    }
+
+    public function testSynonymsExport()
+    {
         $res = $this->index->batchSynonyms(array(
             array(
                 'objectID' => 'city',
@@ -49,19 +61,6 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         ));
 
         $this->index->waitTask($res['taskID'], 0.1);
-    }
-
-    protected function tearDown()
-    {
-        try {
-            $this->client->deleteIndex($this->indexName);
-        } catch (AlgoliaException $e) {
-            // not fatal
-        }
-    }
-
-    public function testSynonymsExport()
-    {
         $i = 0;
         $exported = array();
 
@@ -84,6 +83,25 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
 
         $this->clearSynonyms();
         $this->index->batchSynonyms($exported);
+    }
+
+    public function testCanGetCurrentSynonymOfNewBrowser()
+    {
+        $res = $this->index->saveSynonym('city',
+            array(
+                'type'     => 'synonym',
+                'synonyms' => array('San Francisco', 'SF'),
+            )
+        );
+        $this->index->waitTask($res['taskID'], 0.1);
+
+
+        $synonym = $this->index->initSynonymBrowser()->current();
+        $this->assertEquals(array(
+            'objectID' => 'city',
+            'type'     => 'synonym',
+            'synonyms' => array('San Francisco', 'SF'),
+        ), $synonym);
     }
 
     private function clearSynonyms()

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -5,7 +5,6 @@ namespace AlgoliaSearch\Tests;
 use AlgoliaSearch\AlgoliaException;
 use AlgoliaSearch\Client;
 use AlgoliaSearch\Index;
-use AlgoliaSearch\SynonymType;
 
 class SynonymsExportTest extends AlgoliaSearchTestCase
 {
@@ -66,7 +65,7 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $i = 0;
         $exported = array();
 
-        $browser = $this->index->exportSynonyms(array(), 2);
+        $browser = $this->index->exportSynonyms(2);
 
         foreach ($browser as $k => $synonym) {
             // Check if the key is correct, not related to pagination


### PR DESCRIPTION
This class allows you to easily browse (or export) all your synonyms, just like you browse the records of your index.

I would like feedback on how the array of a single synonym should be formatted. Currently, it's as follow:

```
Array
(
    [type] => altCorrection1
    [word] => Avenue
    [corrections] => Array
        (
            [0] => Av
            [1] => Ave
        )

    [objectID] => avenue
)
```