### PR TITLE
Introduce RuleIterator

### DIFF
--- a/algoliasearch.php
+++ b/algoliasearch.php
@@ -37,3 +37,6 @@ require_once 'src/AlgoliaSearch/Json.php';
 require_once 'src/AlgoliaSearch/FailingHostsCache.php';
 require_once 'src/AlgoliaSearch/FileFailingHostsCache.php';
 require_once 'src/AlgoliaSearch/InMemoryFailingHostsCache.php';
+require_once 'src/AlgoliaSearch/Iterators/AlgoliaIterator.php';
+require_once 'src/AlgoliaSearch/Iterators/RuleIterator.php';
+require_once 'src/AlgoliaSearch/Iterators/SynonymIterator.php';

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1509,9 +1509,9 @@ class Index
         );
     }
 
-    public function initSynonymBrowser($batchSize = 1000)
+    public function initSynonymIterator($batchSize = 1000)
     {
-        return new SynonymBrowser($this, $batchSize);
+        return new SynonymIterator($this, $batchSize);
     }
 
     /**

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -27,6 +27,9 @@
 
 namespace AlgoliaSearch;
 
+
+use AlgoliaSearch\Iterators\SynonymIterator;
+
 /*
  * Contains all the functions related to one index
  * You should use Client.initIndex(indexName) to retrieve this object

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -28,6 +28,7 @@
 namespace AlgoliaSearch;
 
 
+use AlgoliaSearch\Iterators\RuleIterator;
 use AlgoliaSearch\Iterators\SynonymIterator;
 
 /*
@@ -1512,6 +1513,11 @@ class Index
         );
     }
 
+    /**
+     * @param int $batchSize
+     *
+     * @return SynonymIterator
+     */
     public function initSynonymIterator($batchSize = 1000)
     {
         return new SynonymIterator($this, $batchSize);
@@ -1663,6 +1669,16 @@ class Index
             $this->context->connectTimeout,
             $this->context->readTimeout
         );
+    }
+
+    /**
+     * @param int $batchSize
+     *
+     * @return RuleIterator
+     */
+    public function initRuleIterator($batchSize = 500)
+    {
+        return new RuleIterator($this, $batchSize);
     }
 
     /**

--- a/src/AlgoliaSearch/Iterators/AlgoliaIterator.php
+++ b/src/AlgoliaSearch/Iterators/AlgoliaIterator.php
@@ -1,33 +1,36 @@
 <?php
 
-namespace AlgoliaSearch;
+namespace AlgoliaSearch\Iterators;
 
 
-class SynonymIterator implements \Iterator
+use AlgoliaSearch\Index;
+
+abstract class AlgoliaIterator implements \Iterator
 {
     /**
      * @var Index
      */
-    private $index;
+    protected $index;
 
     /**
      * @var int Number of results to return from each call to Algolia
      */
-    private $hitsPerPage;
+    protected $hitsPerPage;
 
     /**
      * @var int
      */
-    private $key = 0;
+    protected $key = 0;
 
     /**
      * @var array Response from the last Algolia API call,
      * this contains the results for the current page.
      */
-    private $response;
+    protected $response;
 
     /**
-     * SynonymBrowser constructor.
+     * Iterator constructor.
+     *
      * @param Index $index
      * @param int $hitsPerPage
      */
@@ -102,35 +105,13 @@ class SynonymIterator implements \Iterator
     }
 
     /**
-     * The export method is using search internally, this method
-     * is used to clean the results, like remove the highlight
-     *
-     * @param array $hit
-     * @return array formatted synonym array
-     */
-    private function formatHit(array $hit)
-    {
-        unset($hit['_highlightResult']);
-
-        return $hit;
-    }
-
-    /**
      * ensureResponseExists is always called prior
      * to trying to access the response property.
      */
-    private function ensureResponseExists() {
+    protected function ensureResponseExists() {
         if ($this->response === null) {
             $this->fetchCurrentPageResults();
         }
-    }
-
-    /**
-     * Call Algolia' API to get new result batch
-     */
-    private function fetchCurrentPageResults()
-    {
-        $this->response = $this->index->searchSynonyms('', array(), $this->getCurrentPage(), $this->hitsPerPage);
     }
 
     /**
@@ -139,7 +120,7 @@ class SynonymIterator implements \Iterator
      *
      * @return int
      */
-    private function getCurrentPage()
+    protected function getCurrentPage()
     {
         return (int) floor($this->key / ($this->hitsPerPage));
     }
@@ -150,8 +131,22 @@ class SynonymIterator implements \Iterator
      *
      * @return int
      */
-    private function getHitIndexForCurrentPage()
+    protected function getHitIndexForCurrentPage()
     {
         return $this->key - ($this->getCurrentPage() * $this->hitsPerPage);
     }
+
+    /**
+     * Call Algolia' API to get new result batch
+     */
+    abstract protected function fetchCurrentPageResults();
+
+    /**
+     * The export method might be is using search internally, this method
+     * is used to clean the results, like remove the highlight
+     *
+     * @param array $hit
+     * @return array formatted synonym array
+     */
+    abstract protected function formatHit(array $hit);
 }

--- a/src/AlgoliaSearch/Iterators/RuleIterator.php
+++ b/src/AlgoliaSearch/Iterators/RuleIterator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AlgoliaSearch\Iterators;
+
+
+use AlgoliaSearch\Index;
+
+class RuleIterator extends AlgoliaIterator
+{
+    public function __construct(Index $index, $hitsPerPage = 500)
+    {
+        parent::__construct($index, $hitsPerPage);
+    }
+
+    /**
+     * The export method is using search internally, this method
+     * is used to clean the results, like remove the highlight
+     *
+     * @param array $hit
+     * @return array formatted synonym array
+     */
+    protected function formatHit(array $hit)
+    {
+        unset($hit['_highlightResult']);
+
+        return $hit;
+    }
+
+    /**
+     * Call Algolia' API to get new result batch
+     */
+    protected function fetchCurrentPageResults()
+    {
+        $this->response = $this->index->searchRules(array(
+            'hitsPerPage' => $this->hitsPerPage,
+            'page' => $this->getCurrentPage(),
+        ));
+    }
+}

--- a/src/AlgoliaSearch/Iterators/SynonymIterator.php
+++ b/src/AlgoliaSearch/Iterators/SynonymIterator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AlgoliaSearch\Iterators;
+
+
+class SynonymIterator extends AlgoliaIterator
+{
+    /**
+     * The export method is using search internally, this method
+     * is used to clean the results, like remove the highlight
+     *
+     * @param array $hit
+     * @return array formatted synonym array
+     */
+    protected function formatHit(array $hit)
+    {
+        unset($hit['_highlightResult']);
+
+        return $hit;
+    }
+
+    /**
+     * Call Algolia' API to get new result batch
+     */
+    protected function fetchCurrentPageResults()
+    {
+        $this->response = $this->index->searchSynonyms('', array(), $this->getCurrentPage(), $this->hitsPerPage);
+    }
+}

--- a/src/AlgoliaSearch/SynonymIterator.php
+++ b/src/AlgoliaSearch/SynonymIterator.php
@@ -3,7 +3,7 @@
 namespace AlgoliaSearch;
 
 
-class SynonymBrowser implements \Iterator
+class SynonymIterator implements \Iterator
 {
     /**
      * @var Index

--- a/tests/AlgoliaSearch/Tests/RulesExportTest.php
+++ b/tests/AlgoliaSearch/Tests/RulesExportTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+
+use AlgoliaSearch\AlgoliaException;
+use AlgoliaSearch\Client;
+use AlgoliaSearch\Index;
+use AlgoliaSearch\Iterators\RuleIterator;
+
+class RulesExportTest extends AlgoliaSearchTestCase
+{
+    /** @var Client */
+    private $client;
+
+    /** @var Index */
+    private $index;
+
+    private $indexName = 'test-rule-export-php';
+
+    protected function setUp()
+    {
+        $this->client = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'));
+        $this->index = $this->client->initIndex($this->indexName);
+        $this->index->addObject(array('note' => 'Create index in Algolia'));
+
+        try {
+            $res = $this->index->clearRules();
+            $this->index->waitTask($res['taskID'], 0.1);
+        } catch (AlgoliaException $e) {
+            // not fatal
+        }
+    }
+
+    protected function tearDown()
+    {
+        try {
+            $this->client->deleteIndex($this->indexName);
+        } catch (AlgoliaException $e) {
+            // not fatal
+        }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testShouldRejectInvalidHitsPerPage()
+    {
+        new RuleIterator($this->index, 0);
+    }
+
+    public function testCanGetCurrentRuleOfNewIterator()
+    {
+        $stub = $this->getRuleStub('stub-1');
+        $res = $this->index->saveRule('stub-1', $stub);
+        $this->index->waitTask($res['taskID'], 0.1);
+
+        $rule = $this->index->initRuleIterator()->current();
+
+        $this->assertEquals($stub, $rule);
+    }
+
+    public function testRulesExport()
+    {
+        $res = $this->index->batchRules(array(
+            $this->getRuleStub('rule-1'),
+            $this->getRuleStub('rule-2'),
+            $this->getRuleStub('rule-3'),
+        ));
+        $this->index->waitTask($res['taskID'], 0.1);
+
+        $exported = array();
+        $iterator = $this->index->initRuleIterator(2);
+
+        $i = 0;
+        foreach ($iterator as $key => $rule) {
+            $this->assertArrayNotHasKey('_highlightResult', $rule);
+            $this->assertEquals($i++, $key);
+
+            $exported[] = $rule;
+        }
+
+        $this->assertCount(3, $exported);
+    }
+
+    public function testFoundRulesCanBeBatched()
+    {
+        $res = $this->index->batchRules(array(
+            $this->getRuleStub('rule-1'),
+            $this->getRuleStub('rule-2'),
+        ));
+        $this->index->waitTask($res['taskID'], 0.1);
+
+
+        $browser = $this->index->initRuleIterator();
+
+        $rules = array();
+        foreach ($browser as $key => $rule) {
+            $rules[] = $rule;
+        }
+
+        $res = $this->index->clearRules();
+        $this->index->waitTask($res['taskID']);
+
+        $this->index->batchRules($rules);
+    }
+
+    private function getRuleStub($objectID = 'my-rule')
+    {
+        return $rule = array(
+            'objectID' => $objectID,
+            'condition' => array(
+                'pattern'   => 'some text',
+                'anchoring' => 'is'
+            ),
+            'consequence' => array(
+                'params' => array(
+                    'query' => 'other text'
+                )
+            )
+        );
+    }
+}

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -5,7 +5,7 @@ namespace AlgoliaSearch\Tests;
 use AlgoliaSearch\AlgoliaException;
 use AlgoliaSearch\Client;
 use AlgoliaSearch\Index;
-use AlgoliaSearch\SynonymIterator;
+use AlgoliaSearch\Iterators\SynonymIterator;
 
 class SynonymsExportTest extends AlgoliaSearchTestCase
 {

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -5,7 +5,7 @@ namespace AlgoliaSearch\Tests;
 use AlgoliaSearch\AlgoliaException;
 use AlgoliaSearch\Client;
 use AlgoliaSearch\Index;
-use AlgoliaSearch\SynonymBrowser;
+use AlgoliaSearch\SynonymIterator;
 
 class SynonymsExportTest extends AlgoliaSearchTestCase
 {
@@ -45,10 +45,10 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
      */
     public function testShouldRejectInvalidHitsPerPage()
     {
-        new SynonymBrowser($this->index, 0);
+        new SynonymIterator($this->index, 0);
     }
 
-    public function testCanGetCurrentSynonymOfNewBrowser()
+    public function testCanGetCurrentSynonymOfNewIterator()
     {
         $res = $this->index->saveSynonym('city',
             array(
@@ -59,7 +59,7 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $this->index->waitTask($res['taskID'], 0.1);
 
 
-        $synonym = $this->index->initSynonymBrowser()->current();
+        $synonym = $this->index->initSynonymIterator()->current();
         $this->assertEquals(array(
             'objectID' => 'city',
             'type'     => 'synonym',
@@ -73,11 +73,10 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $this->index->waitTask($res['taskID'], 0.1);
 
         $exported = array();
-
-        $browser = $this->index->initSynonymBrowser(2);
+        $iterator = $this->index->initSynonymIterator(2);
 
         $i = 0;
-        foreach ($browser as $key => $synonym) {
+        foreach ($iterator as $key => $synonym) {
             $this->assertArrayNotHasKey('_highlightResult', $synonym);
             $this->assertEquals($i++, $key);
 
@@ -93,10 +92,10 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
         $this->index->waitTask($res['taskID'], 0.1);
 
 
-        $browser = $this->index->initSynonymBrowser();
+        $iterator = $this->index->initSynonymIterator();
 
         $synonyms = array();
-        foreach ($browser as $key => $synonym) {
+        foreach ($iterator as $key => $synonym) {
             $synonyms[] = $synonym;
         }
 


### PR DESCRIPTION
Most of the Iterator code was extracted to `AlgoliaIterator` and both synonyms and rules rely extend this class.

Rules are limited to 500 by default because the API will currently reject 1000. The python API clients will update to 500 too.