### PR TITLE
Replacing curl with Guzzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor
 composer.lock
 .php_cs.cache
 tests/AlgoliaSearch/Tests/cache_dir/
+.idea/
+composer.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### 2.0.0
+
+- feat: Replace curl with Guzzle (guzzlephp.org)
+
 ### 1.23.0
 
 - feat: add a `requestHeaders` parameter to every method to allow passing custom HTTP headers on a per request basis

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,16 @@
         {
             "name": "Ryan T. Catlin",
             "email": "ryan.catlin@gmail.com"
+        },
+        {
+            "name": "Geoffrey Arnold",
+            "email": "geoffrey@geoffreyarnold.com"
         }
     ],
     "require": {
         "php": ">=5.3",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "satooshi/php-coveralls": "0.6.*",

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -1107,7 +1107,7 @@ class Client
 
         $options[GuzzleRequestOptions::HEADERS] = $headers;
         $options[GuzzleRequestOptions::HTTP_ERRORS] = false;
-        $options[GuzzleRequestOptions::VERIFY] = $this->caInfoPath;
+        $options[GuzzleRequestOptions::VERIFY] = self::isGoogleAppEngine() ? false : $this->caInfoPath;
         $options[GuzzleRequestOptions::TIMEOUT] = $options[GuzzleRequestOptions::CONNECT_TIMEOUT] = $connectTimeout;
         $options[GuzzleRequestOptions::READ_TIMEOUT] = $readTimeout;
 
@@ -1218,5 +1218,16 @@ class Client
     public function getContext()
     {
         return $this->context;
+    }
+
+    /**
+     * Recommended way to check if script is running in Google App Engine:
+     * https://github.com/google/google-api-php-client/blob/master/src/Google/Client.php#L799
+     *
+     * @return bool Returns true if running in Google App Engine
+     */
+    private static function isGoogleAppEngine()
+    {
+        return (isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'Google App Engine') !== false);
     }
 }

--- a/src/AlgoliaSearch/ClientContext.php
+++ b/src/AlgoliaSearch/ClientContext.php
@@ -52,11 +52,6 @@ class ClientContext
     public $writeHostsArray;
 
     /**
-     * @var resource
-     */
-    public $curlMHandle;
-
-    /**
      * @var string
      */
     public $adminAPIKey;
@@ -120,7 +115,6 @@ class ClientContext
             throw new Exception('AlgoliaSearch requires an apiKey.');
         }
 
-        $this->curlMHandle = null;
         $this->adminAPIKey = null;
         $this->endUserIP = null;
         $this->algoliaUserToken = null;
@@ -180,39 +174,6 @@ class ClientContext
         array_unshift($hosts, $this->applicationID.'.algolia.net');
 
         return $hosts;
-    }
-
-    /**
-     * Closes eventually opened curl handles.
-     */
-    public function __destruct()
-    {
-        if (is_resource($this->curlMHandle)) {
-            curl_multi_close($this->curlMHandle);
-        }
-    }
-
-    /**
-     * @param $curlHandle
-     *
-     * @return resource
-     */
-    public function getMHandle($curlHandle)
-    {
-        if (!is_resource($this->curlMHandle)) {
-            $this->curlMHandle = curl_multi_init();
-        }
-        curl_multi_add_handle($this->curlMHandle, $curlHandle);
-
-        return $this->curlMHandle;
-    }
-
-    /**
-     * @param $curlHandle
-     */
-    public function releaseMHandle($curlHandle)
-    {
-        curl_multi_remove_handle($this->curlMHandle, $curlHandle);
     }
 
     /**

--- a/tests/AlgoliaSearch/Tests/AccessTest.php
+++ b/tests/AlgoliaSearch/Tests/AccessTest.php
@@ -28,7 +28,7 @@ class AccessTest extends AlgoliaSearchTestCase
 
     public function testAccessWithOptions()
     {
-        $client = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'), null, array('curloptions' => array('CURLOPT_FAILONERROR' => 0)));
+        $client = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'), null, array('guzzle' => array('http_errors' => false)));
 
         $client->isAlive();
     }


### PR DESCRIPTION
The PHP cURL extension [causes intermittent issues when running on Google App Engine](https://code.google.com/p/googleappengine/issues/detail?id=12451).  Guzzle provides an abstraction layer for HTTP requests, which allows you to change the underlying service without rewriting application code, and is [the recommended way to issue HTTP requests when using PHP on GAE](https://cloud.google.com/appengine/docs/php/issue-requests#issuing_an_http_request).

Guzzle will continue to use cURL if the extension is enabled, and fallback to stream handlers.