### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "0.6.*",
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "satooshi/php-coveralls": "^1.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4"
     },
     "autoload": {
         "psr-0": {

--- a/tests/AlgoliaSearch/Tests/AlgoliaSearchTestCase.php
+++ b/tests/AlgoliaSearch/Tests/AlgoliaSearchTestCase.php
@@ -2,7 +2,9 @@
 
 namespace AlgoliaSearch\Tests;
 
-class AlgoliaSearchTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AlgoliaSearchTestCase extends TestCase
 {
     public function safe_name($name)
     {

--- a/tests/AlgoliaSearch/Tests/ClientContextTest.php
+++ b/tests/AlgoliaSearch/Tests/ClientContextTest.php
@@ -7,8 +7,9 @@ require_once 'global_functions_stubs.php';
 use AlgoliaSearch\ClientContext;
 use AlgoliaSearch\FileFailingHostsCache;
 use AlgoliaSearch\InMemoryFailingHostsCache;
+use PHPUnit\Framework\TestCase;
 
-class ClientContextTest extends \PHPUnit_Framework_TestCase
+class ClientContextTest extends TestCase
 {
     protected function tearDown()
     {

--- a/tests/AlgoliaSearch/Tests/ClientTest.php
+++ b/tests/AlgoliaSearch/Tests/ClientTest.php
@@ -6,8 +6,9 @@ use AlgoliaSearch\Client;
 use AlgoliaSearch\ClientContext;
 use AlgoliaSearch\FileFailingHostsCache;
 use AlgoliaSearch\InMemoryFailingHostsCache;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/AlgoliaSearch/Tests/DeleteTest.php
+++ b/tests/AlgoliaSearch/Tests/DeleteTest.php
@@ -45,7 +45,6 @@ class DeleteTest extends AlgoliaSearchTestCase
         $results = $this->index->search('');
         $this->assertEquals(0, $results['nbHits']);
 
-        $this->setExpectedException('Exception');
         $this->index->deleteObject(null);
     }
 }

--- a/tests/AlgoliaSearch/Tests/FailingHostsCacheTestCase.php
+++ b/tests/AlgoliaSearch/Tests/FailingHostsCacheTestCase.php
@@ -3,8 +3,9 @@
 namespace AlgoliaSearch\Tests;
 
 use AlgoliaSearch\FailingHostsCache;
+use PHPUnit\Framework\TestCase;
 
-abstract class FailingHostsCacheTestCase extends \PHPUnit_Framework_TestCase
+abstract class FailingHostsCacheTestCase extends TestCase
 {
     public function testShouldDeduplicateFailingHosts()
     {
@@ -35,16 +36,16 @@ abstract class FailingHostsCacheTestCase extends \PHPUnit_Framework_TestCase
     public function testShouldShareFailingHostsBetweenInstances()
     {
         $cache = $this->getNewCleanCacheInstance();
-        
+
         $cache->addFailingHost('host1.com');
 
         $cache2 = $this->getNewCacheInstance();
         $cache2->addFailingHost('host2.com');
-        
+
         // The 2 instances should have the same state.
         $this->assertEquals(array('host1.com', 'host2.com'), $cache->getFailingHosts());
         $this->assertEquals(array('host1.com', 'host2.com'), $cache2->getFailingHosts());
-        
+
         // Clean the state.
         $cache2->flushFailingHostsCache();
 

--- a/tests/AlgoliaSearch/Tests/FileFailingHostsCacheTest.php
+++ b/tests/AlgoliaSearch/Tests/FileFailingHostsCacheTest.php
@@ -6,6 +6,9 @@ use AlgoliaSearch\FileFailingHostsCache;
 
 class FileFailingHostsCacheTest extends FailingHostsCacheTestCase
 {
+    /**
+     * @expectedException RuntimeException
+     */
     public function testShouldThrowAnExceptionIfCacheDirectoryIsNotWritable()
     {
         $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
@@ -14,11 +17,14 @@ class FileFailingHostsCacheTest extends FailingHostsCacheTestCase
         @rmdir($dir);
         mkdir($dir, 0555);
 
-        $this->setExpectedException('\RuntimeException', 'Cache file directory "' . $dir . '" is not writable.');
+        $this->expectExceptionMessage('Cache file directory "' . $dir . '" is not writable.');
 
         new FileFailingHostsCache(5, $cacheFile);
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
     public function testShouldThrowAnExceptionIfCacheFileExistsButIsNotReadable()
     {
         $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
@@ -29,11 +35,14 @@ class FileFailingHostsCacheTest extends FailingHostsCacheTestCase
         touch($cacheFile);
         chmod($cacheFile, 0222); // not readable.
 
-        $this->setExpectedException('\RuntimeException', 'Cache file "' . $cacheFile . '" is not readable.');
+        $this->expectExceptionMessage('Cache file "' . $cacheFile . '" is not readable.');
 
         new FileFailingHostsCache(5, $cacheFile);
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
     public function testShouldThrowAnExceptionIfCacheFileExistsButIsNotWritable()
     {
         $dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache_dir';
@@ -44,7 +53,7 @@ class FileFailingHostsCacheTest extends FailingHostsCacheTestCase
         touch($cacheFile);
         chmod($cacheFile, 0555); // not writable.
 
-        $this->setExpectedException('\RuntimeException', 'Cache file "' . $cacheFile . '" is not writable.');
+        $this->expectExceptionMessage('Cache file "' . $cacheFile . '" is not writable.');
 
         new FileFailingHostsCache(5, $cacheFile);
     }

--- a/tests/AlgoliaSearch/Tests/FunctionTest.php
+++ b/tests/AlgoliaSearch/Tests/FunctionTest.php
@@ -50,21 +50,27 @@ class FunctionTest extends AlgoliaSearchTestCase
         $this->assertTrue($timeOfFirstQuery > $avgTimeOfTheTenQueries);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testConstructAPIKey()
     {
-        $this->setExpectedException('Exception');
         new Client(getenv('ALGOLIA_APPLICATION_ID'), null);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testConstructAPPID()
     {
-        $this->setExpectedException('Exception');
         new Client(null, getenv('ALGOLIA_API_KEY'));
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testConstructHost()
     {
-        $this->setExpectedException('Exception');
         $host = array('toto');
         $this->badClient = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'), $host);
         $this->badIndex = $this->badClient->initIndex($this->safe_name('àlgol?à-php'));
@@ -72,9 +78,11 @@ class FunctionTest extends AlgoliaSearchTestCase
         $this->badIndex->waitTask($res['taskID']);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testBadAPPIP()
     {
-        $this->setExpectedException('Exception');
         $this->badClient = new Client(getenv('ALGOLIA_APPLICATION_ID'), 'toto');
         $this->index = $this->badClient->listIndexes();
     }

--- a/tests/AlgoliaSearch/Tests/JsonTest.php
+++ b/tests/AlgoliaSearch/Tests/JsonTest.php
@@ -20,18 +20,20 @@ class JsonTest extends AlgoliaSearchTestCase
         $this->assertEquals($array, $decodedArray);
     }
 
+    /**
+     * @expectedException AlgoliaSearch\AlgoliaException
+     */
     public function testMalformedJson()
     {
-        $this->setExpectedException('AlgoliaSearch\AlgoliaException');
-
         $malformedJson = '{"foo":"bar"';
         Json::decode($malformedJson);
     }
 
+    /**
+     * @expectedException AlgoliaSearch\AlgoliaException
+     */
     public function testMalformedString()
     {
-        $this->setExpectedException('AlgoliaSearch\AlgoliaException');
-
         $utf8String = 'ř';
         $malformedString = substr($utf8String, 0, 1);
 


### PR DESCRIPTION
I've added `PHPUnit 6` support.

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support the `PHPUnit\Framework\TestCase` namespace.