### PR TITLE
Introduce Scoped Copy Index

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -364,7 +364,33 @@ class Client
     {
         $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
 
-        $request = array('operation' => 'copy', 'destination' => $dstIndexName);
+        return $this->scopedCopyIndex($srcIndexName, $dstIndexName, array(), $requestHeaders);
+    }
+
+    /**
+     * Copy an existing index and define what to copy along with records:
+     *  - settings
+     *  - synonyms
+     *  - query rules
+     *
+     * By default, everything is copied.
+     *
+     * @param string $srcIndexName the name of index to copy.
+     * @param string $dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overwritten if it already exist).
+     * @param array $scope Resource to copy along with records: 'settings', 'rules', 'synonyms'
+     * @param array $requestHeaders
+     * @return mixed
+     */
+    public function scopedCopyIndex($srcIndexName, $dstIndexName, array $scope = array(), array $requestHeaders = array())
+    {
+        $request = array(
+            'operation' => 'copy',
+            'destination' => $dstIndexName,
+        );
+
+        if (! empty($scope)) {
+            $request['scope'] = $scope;
+        }
 
         return $this->request(
             $this->context,

--- a/tests/AlgoliaSearch/Tests/InitPlacesTest.php
+++ b/tests/AlgoliaSearch/Tests/InitPlacesTest.php
@@ -24,6 +24,7 @@ class InitPlacesTest extends AlgoliaSearchTestCase
     public function testShouldAllowToBeCalledWithoutCredentials()
     {
         Client::initPlaces();
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/AlgoliaSearch/Tests/PlacesIndexTest.php
+++ b/tests/AlgoliaSearch/Tests/PlacesIndexTest.php
@@ -3,14 +3,16 @@
 namespace AlgoliaSearch\Tests;
 
 use AlgoliaSearch\Client;
+use AlgoliaSearch\PlacesIndex;
 
 class PlacesIndexTest extends AlgoliaSearchTestCase
 {
     public function testGetObject()
     {
+        /** @var PlacesIndex $placesIndex */
         $placesIndex = Client::initPlaces();
-        $response = $placesIndex->getObject('171457082_7444');
+        $response = $placesIndex->search('Paris', array('hitsPerPage' => 12));
 
-        $this->assertEquals('171457082_7444', $response['objectID']);
+        $this->assertEquals(12, count($response['hits']));
     }
 }


### PR DESCRIPTION
Please note that for internal reason when scopedCopyIndex doesn't include `settings`, the engine will notre create the index. You have to create it manually before or after.