### PR TITLE
Refactoring tests

### DIFF
--- a/tests/AlgoliaSearch/Tests/BasicTest.php
+++ b/tests/AlgoliaSearch/Tests/BasicTest.php
@@ -143,7 +143,7 @@ class BasicTest extends AlgoliaSearchTestCase
         ));
 
         $this->assertEquals(3, $results['results'][0]['nbHits']);
-        $this->assertEquals(3, count($results['results'][0]['hits']));
+        $this->assertCount(3, $results['results'][0]['hits']);
 
         $results = $this->client->multipleQueries(array(
             array(
@@ -163,7 +163,7 @@ class BasicTest extends AlgoliaSearchTestCase
             ),
         ), 'indexName', 'stopIfEnoughMatches');
 
-        $this->assertEquals(1, count($results['results'][0]['hits']));
+        $this->assertCount(1, $results['results'][0]['hits']);
         $this->assertEquals(1, count($results['results'][0]['hits']) + count($results['results'][1]['hits']) + count($results['results'][2]['hits']));
     }
 
@@ -181,28 +181,28 @@ class BasicTest extends AlgoliaSearchTestCase
 
         $answer = $this->index->searchDisjunctiveFaceting('h', array('stars', 'facilities'), array('facets' => 'city'));
         $this->assertEquals(5, $answer['nbHits']);
-        $this->assertEquals(1, count($answer['facets']));
-        $this->assertEquals(2, count($answer['disjunctiveFacets']));
+        $this->assertCount(1, $answer['facets']);
+        $this->assertCount(2, $answer['disjunctiveFacets']);
 
         $answer = $this->index->searchDisjunctiveFaceting('h', array('stars', 'facilities'), array('facets' => 'city'), array('stars' => array('*')));
         $this->assertEquals(2, $answer['nbHits']);
-        $this->assertEquals(1, count($answer['facets']));
-        $this->assertEquals(2, count($answer['disjunctiveFacets']));
+        $this->assertCount(1, $answer['facets']);
+        $this->assertCount(2, $answer['disjunctiveFacets']);
         $this->assertEquals(2, $answer['disjunctiveFacets']['stars']['*']);
         $this->assertEquals(1, $answer['disjunctiveFacets']['stars']['**']);
         $this->assertEquals(2, $answer['disjunctiveFacets']['stars']['****']);
 
         $answer = $this->index->searchDisjunctiveFaceting('h', array('stars', 'facilities'), array('facets' => 'city'), array('stars' => array('*'), 'city' => array('Paris')));
         $this->assertEquals(2, $answer['nbHits']);
-        $this->assertEquals(1, count($answer['facets']));
-        $this->assertEquals(2, count($answer['disjunctiveFacets']));
+        $this->assertCount(1, $answer['facets']);
+        $this->assertCount(2, $answer['disjunctiveFacets']);
         $this->assertEquals(2, $answer['disjunctiveFacets']['stars']['*']);
         $this->assertEquals(1, $answer['disjunctiveFacets']['stars']['****']);
 
         $answer = $this->index->searchDisjunctiveFaceting('h', array('stars', 'facilities'), array('facets' => 'city'), array('stars' => array('*', '****'), 'city' => array('Paris')));
         $this->assertEquals(3, $answer['nbHits']);
-        $this->assertEquals(1, count($answer['facets']));
-        $this->assertEquals(2, count($answer['disjunctiveFacets']));
+        $this->assertCount(1, $answer['facets']);
+        $this->assertCount(2, $answer['disjunctiveFacets']);
         $this->assertEquals(2, $answer['disjunctiveFacets']['stars']['*']);
         $this->assertEquals(1, $answer['disjunctiveFacets']['stars']['****']);
     }

--- a/tests/AlgoliaSearch/Tests/FunctionTest.php
+++ b/tests/AlgoliaSearch/Tests/FunctionTest.php
@@ -47,7 +47,7 @@ class FunctionTest extends AlgoliaSearchTestCase
         // Makes sure that we re-use the connection by leveraging Keep-Alive.
         // The first query should take more time to be processed given it opens the connection and handles the handshake.
         // Subsequent queries should re-use the cURL resource and the underlying opened connection.
-        $this->assertTrue($timeOfFirstQuery > $avgTimeOfTheTenQueries);
+        $this->assertGreaterThan($avgTimeOfTheTenQueries, $timeOfFirstQuery);
     }
 
     public function testConstructAPIKey()

--- a/tests/AlgoliaSearch/Tests/GetTest.php
+++ b/tests/AlgoliaSearch/Tests/GetTest.php
@@ -47,27 +47,27 @@ class GetTest extends AlgoliaSearchTestCase
         $this->assertEquals('Robin', $results['hits'][0]['firstname']);
 
         $obj = $this->index->getObject('à/go/?à');
-        $this->assertTrue(isset($obj['firstname']));
-        $this->assertTrue(isset($obj['lastname']));
+        $this->assertArrayHasKey('firstname', $obj);
+        $this->assertArrayHasKey('lastname', $obj);
         $this->assertEquals('Robin', $obj['firstname']);
 
         $obj = $this->index->getObject('à/go/?à', 'firstname');
-        $this->assertTrue(isset($obj['firstname']));
-        $this->assertFalse(isset($obj['lastname']));
+        $this->assertArrayHasKey('firstname', $obj);
+        $this->assertArrayNotHasKey('lastname', $obj);
 
         $obj = $this->index->getObject('à/go/?à', array('firstname'));
-        $this->assertTrue(isset($obj['firstname']));
-        $this->assertFalse(isset($obj['lastname']));
+        $this->assertArrayHasKey('firstname', $obj);
+        $this->assertArrayNotHasKey('lastname', $obj);
 
         $obj = $this->index->getObject('à/go/?à', '');
-        $this->assertTrue(isset($obj['objectID']));
-        $this->assertFalse(isset($obj['firstname']));
-        $this->assertFalse(isset($obj['lastname']));
+        $this->assertArrayHasKey('objectID', $obj);
+        $this->assertArrayNotHasKey('firstname', $obj);
+        $this->assertArrayNotHasKey('lastname', $obj);
 
         $obj = $this->index->getObject('à/go/?à', array());
-        $this->assertTrue(isset($obj['objectID']));
-        $this->assertFalse(isset($obj['firstname']));
-        $this->assertFalse(isset($obj['lastname']));
+        $this->assertArrayHasKey('objectID', $obj);
+        $this->assertArrayNotHasKey('firstname', $obj);
+        $this->assertArrayNotHasKey('lastname', $obj);
     }
 
     public function testGetObjects()
@@ -102,36 +102,36 @@ class GetTest extends AlgoliaSearchTestCase
         $objects4 = $this->index->getObjects(array($results['hits'][0]['objectID'], $results['hits'][1]['objectID']), '');
         $objects5 = $this->index->getObjects(array($results['hits'][0]['objectID'], $results['hits'][1]['objectID']), array());
 
-        $this->assertEquals(2, count($objects1['results']));
-        $this->assertEquals(2, count($objects2['results']));
-        $this->assertEquals(2, count($objects3['results']));
-        $this->assertEquals(2, count($objects4['results']));
-        $this->assertEquals(2, count($objects5['results']));
+        $this->assertCount(2, $objects1['results']);
+        $this->assertCount(2, $objects2['results']);
+        $this->assertCount(2, $objects3['results']);
+        $this->assertCount(2, $objects4['results']);
+        $this->assertCount(2, $objects5['results']);
 
         $firstResult = reset($objects1['results']);
-        $this->assertTrue(isset($firstResult['objectID']));
-        $this->assertTrue(isset($firstResult['firstname']));
-        $this->assertTrue(isset($firstResult['lastname']));
+        $this->assertArrayHasKey('objectID', $firstResult);
+        $this->assertArrayHasKey('firstname', $firstResult);
+        $this->assertArrayHasKey('lastname', $firstResult);
 
         $secondResult = reset($objects2['results']);
-        $this->assertTrue(isset($secondResult['objectID']));
-        $this->assertFalse(isset($secondResult['firstname']));
-        $this->assertTrue(isset($secondResult['lastname']));
+        $this->assertArrayHasKey('objectID', $secondResult);
+        $this->assertArrayNotHasKey('firstname', $secondResult);
+        $this->assertArrayHasKey('lastname', $secondResult);
 
         $thirdResult = reset($objects3['results']);
-        $this->assertTrue(isset($thirdResult['objectID']));
-        $this->assertFalse(isset($thirdResult['firstname']));
-        $this->assertTrue(isset($thirdResult['lastname']));
+        $this->assertArrayHasKey('objectID', $thirdResult);
+        $this->assertArrayNotHasKey('firstname', $thirdResult);
+        $this->assertArrayHasKey('lastname', $thirdResult);
 
         $fourthResult = reset($objects4['results']);
-        $this->assertTrue(isset($fourthResult['objectID']));
-        $this->assertTrue(isset($fourthResult['firstname']));
-        $this->assertTrue(isset($fourthResult['lastname']));
+        $this->assertArrayHasKey('objectID', $fourthResult);
+        $this->assertArrayHasKey('firstname', $fourthResult);
+        $this->assertArrayHasKey('lastname', $fourthResult);
 
         $fifthResult = reset($objects5['results']);
-        $this->assertTrue(isset($fifthResult['objectID']));
-        $this->assertTrue(isset($fifthResult['firstname']));
-        $this->assertTrue(isset($fifthResult['lastname']));
+        $this->assertArrayHasKey('objectID', $fifthResult);
+        $this->assertArrayHasKey('firstname', $fifthResult);
+        $this->assertArrayHasKey('lastname', $fifthResult);
     }
 
     public function testGetSaveObjects()

--- a/tests/AlgoliaSearch/Tests/MultiClusterManagementTest.php
+++ b/tests/AlgoliaSearch/Tests/MultiClusterManagementTest.php
@@ -30,12 +30,12 @@ class MultiClusterManagementTest extends AlgoliaSearchTestCase
         $answer = $this->client->listClusters();
 
 
-        $this->assertTrue($answer['clusters'] !== null);
-        $this->assertTrue(count($answer['clusters']) > 0);
-        $this->assertTrue($answer['clusters'][0]['clusterName'] !== null);
-        $this->assertTrue($answer['clusters'][0]['nbRecords'] !== null);
-        $this->assertTrue($answer['clusters'][0]['nbUserIDs'] !== null);
-        $this->assertTrue($answer['clusters'][0]['dataSize'] !== null);
+        $this->assertNotNull($answer['clusters']);
+        $this->assertGreaterThan(0, count($answer['clusters']));
+        $this->assertNotNull($answer['clusters'][0]['clusterName']);
+        $this->assertNotNull($answer['clusters'][0]['nbRecords']);
+        $this->assertNotNull($answer['clusters'][0]['nbUserIDs']);
+        $this->assertNotNull($answer['clusters'][0]['dataSize']);
     }
 
     public function testAssignUserID() {
@@ -43,19 +43,19 @@ class MultiClusterManagementTest extends AlgoliaSearchTestCase
         $cluster = $clusters['clusters'][0]['clusterName'];
         $answer = $this->client->assignUserID($this->userID, $cluster);
 
-        $this->assertTrue($answer['createdAt'] !== null);
+        $this->assertNotNull($answer['createdAt']);
         sleep(2); // Sleep to let the cluster publish the change
     }
 
     public function testListUserIDs() {
         $answer = $this->client->listUserIDs();
 
-        $this->assertTrue($answer['userIDs'] !== null);
-        $this->assertTrue(count($answer['userIDs']) > 0);
-        $this->assertTrue($answer['userIDs'][0]['userID'] !== null);
-        $this->assertTrue($answer['userIDs'][0]['clusterName'] !== null);
-        $this->assertTrue($answer['userIDs'][0]['nbRecords'] !== null);
-        $this->assertTrue($answer['userIDs'][0]['dataSize'] !== null);
+        $this->assertNotNull($answer['userIDs']);
+        $this->assertGreaterThan(0, count($answer['userIDs']));
+        $this->assertNotNull($answer['userIDs'][0]['userID']);
+        $this->assertNotNull($answer['userIDs'][0]['clusterName']);
+        $this->assertNotNull($answer['userIDs'][0]['nbRecords']);
+        $this->assertNotNull($answer['userIDs'][0]['dataSize']);
     }
 
     public function testGetTopUserID() {
@@ -63,21 +63,21 @@ class MultiClusterManagementTest extends AlgoliaSearchTestCase
         $cluster = $clusters['clusters'][0]['clusterName'];
         $answer = $this->client->getTopUserID();
 
-        $this->assertTrue($answer['topUsers'] !== null);
-        $this->assertTrue(count($answer['topUsers']) > 0);
-        $this->assertTrue(count($answer['topUsers'][$cluster]) > 0);
-        $this->assertTrue($answer['topUsers'][$cluster][0]['userID'] !== null);
-        $this->assertTrue($answer['topUsers'][$cluster][0]['nbRecords'] !== null);
-        $this->assertTrue($answer['topUsers'][$cluster][0]['dataSize'] !== null);
+        $this->assertNotNull($answer['topUsers']);
+        $this->assertGreaterThan(0, count($answer['topUsers']));
+        $this->assertGreaterThan(0, count($answer['topUsers'][$cluster]));
+        $this->assertNotNull($answer['topUsers'][$cluster][0]['userID']);
+        $this->assertNotNull($answer['topUsers'][$cluster][0]['nbRecords']);
+        $this->assertNotNull($answer['topUsers'][$cluster][0]['dataSize']);
     }
 
     public function testGetUserID() {
         $answer = $this->client->getUserID($this->userID);
 
-        $this->assertTrue($answer['userID'] !== null);
-        $this->assertTrue($answer['clusterName'] !== null);
-        $this->assertTrue($answer['nbRecords'] !== null);
-        $this->assertTrue($answer['dataSize'] !== null);
+        $this->assertNotNull($answer['userID']);
+        $this->assertNotNull($answer['clusterName']);
+        $this->assertNotNull($answer['nbRecords']);
+        $this->assertNotNull($answer['dataSize']);
     }
 
     public function testSearchUserIDs() {
@@ -85,20 +85,20 @@ class MultiClusterManagementTest extends AlgoliaSearchTestCase
         $cluster = $clusters['clusters'][0]['clusterName'];
         $answer = $this->client->searchUserIDs($this->userID, $cluster, 0, 1000);
 
-        $this->assertTrue($answer['hits'] !== null);
-        $this->assertTrue($answer['nbHits'] !== null);
-        $this->assertTrue($answer['page'] == 0);
-        $this->assertTrue($answer['hitsPerPage'] == 1000);
-        $this->assertTrue(count($answer['hits']) > 0);
-        $this->assertTrue($answer['hits'][0]['userID'] !== null);
-        $this->assertTrue($answer['hits'][0]['clusterName'] !== null);
-        $this->assertTrue($answer['hits'][0]['nbRecords'] !== null);
-        $this->assertTrue($answer['hits'][0]['dataSize'] !== null);
+        $this->assertNotNull($answer['hits']);
+        $this->assertNotNull($answer['nbHits']);
+        $this->assertEquals(0, $answer['page']);
+        $this->assertEquals(1000, $answer['hitsPerPage']);
+        $this->assertGreaterThan(0, count($answer['hits']));
+        $this->assertNotNull($answer['hits'][0]['userID']);
+        $this->assertNotNull($answer['hits'][0]['clusterName']);
+        $this->assertNotNull($answer['hits'][0]['nbRecords']);
+        $this->assertNotNull($answer['hits'][0]['dataSize']);
     }
 
     public function testRemoveUserID() {
         $answer = $this->client->removeUserID($this->userID);
 
-        $this->assertTrue($answer['deletedAt'] !== null);
+        $this->assertNotNull($answer['deletedAt']);
     }
 }

--- a/tests/AlgoliaSearch/Tests/SearchFacetTest.php
+++ b/tests/AlgoliaSearch/Tests/SearchFacetTest.php
@@ -82,7 +82,7 @@ class SearchFacetTest extends AlgoliaSearchTestCase
         # Straightforward search.
         $facetHits = $this->index->searchFacet('series', 'Hobb');
         $facetHits = $facetHits['facetHits'];
-        $this->assertEquals(count($facetHits), 1);
+        $this->assertCount(1, $facetHits);
         $this->assertEquals($facetHits[0]['value'], 'Calvin & Hobbes');
         $this->assertEquals($facetHits[0]['count'], 2);
 
@@ -148,7 +148,7 @@ class SearchFacetTest extends AlgoliaSearchTestCase
         # Straightforward search.
         $facetHits = $this->index->searchForFacetValues('series', 'Hobb');
         $facetHits = $facetHits['facetHits'];
-        $this->assertEquals(count($facetHits), 1);
+        $this->assertCount(1, $facetHits);
         $this->assertEquals($facetHits[0]['value'], 'Calvin & Hobbes');
         $this->assertEquals($facetHits[0]['count'], 2);
 

--- a/tests/AlgoliaSearch/Tests/SecurityTest.php
+++ b/tests/AlgoliaSearch/Tests/SecurityTest.php
@@ -42,7 +42,7 @@ class SecurityTest extends AlgoliaSearchTestCase
         $res = $this->index->listUserKeys();
         $newKey = $this->index->addUserKey(array('search'));
 
-        $this->assertTrue($newKey['key'] != '');
+        $this->assertNotEquals('', $newKey['key']);
         $this->assertFalse($this->containsValue($res['keys'], 'value', $newKey['key']));
 
         $self = $this;
@@ -119,7 +119,7 @@ class SecurityTest extends AlgoliaSearchTestCase
         $b->waitTask($res['taskID']);
 
         $newKey = $this->client->addUserKey(array('search', 'addObject', 'deleteObject'), 0, 0, 0, array($this->safe_name('a-12'), $this->safe_name('b-13')));
-        $this->assertTrue($newKey['key'] != '');
+        $this->assertNotEquals('', $newKey['key']);
 
         $self = $this;
         $this->poolingTask(function ($timeouted) use ($newKey, $self) {

--- a/tests/AlgoliaSearch/Tests/SettingsTest.php
+++ b/tests/AlgoliaSearch/Tests/SettingsTest.php
@@ -40,7 +40,7 @@ class SettingsTest extends AlgoliaSearchTestCase
         $res = $this->index->setSettings(array('attributesToRetrieve' => array('firstname'), 'hitsPerPage' => 50));
         $this->index->waitTask($res['taskID']);
         $settings = $this->index->getSettings();
-        $this->assertEquals(count($settings['attributesToRetrieve']), 1);
+        $this->assertCount(1, $settings['attributesToRetrieve']);
         $this->assertEquals($settings['attributesToRetrieve'][0], 'firstname');
     }
 
@@ -58,7 +58,7 @@ class SettingsTest extends AlgoliaSearchTestCase
         $replicaIndex = $this->client->initIndex($this->safe_name('àlgol?à-php-replica'));
         $settings = $replicaIndex->getSettings();
 
-        $this->assertEquals(count($settings['attributesToRetrieve']), 1);
+        $this->assertCount(1, $settings['attributesToRetrieve']);
         $this->assertEquals($settings['attributesToRetrieve'][0], 'firstname');
     }
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertNotNull` instead of comparison with `null` keyword;
- `assertNotEquals` instead of comparisons `!=`;
- `assertGreaterThan` for mathematical comparions;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `isset` function.