### PR TITLE
Restore backward compat' for initSynonymBrowser

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1634,6 +1634,16 @@ class Index
     }
 
     /**
+     * @deprecated Please use initSynonymIterator instead
+     * @param int $batchSize
+     * @return SynonymIterator
+     */
+    public function initSynonymBrowser($batchSize = 1000)
+    {
+        return $this->initSynonymIterator($batchSize);
+    }
+
+    /**
      * @deprecated Please use searchForFacetValues instead
      * @param $facetName
      * @param $facetQuery

--- a/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
+++ b/tests/AlgoliaSearch/Tests/SynonymsExportTest.php
@@ -65,6 +65,14 @@ class SynonymsExportTest extends AlgoliaSearchTestCase
             'type'     => 'synonym',
             'synonyms' => array('San Francisco', 'SF'),
         ), $synonym);
+
+        // Test for backward compatibility
+        $synonym = $this->index->initSynonymBrowser()->current();
+        $this->assertEquals(array(
+            'objectID' => 'city',
+            'type'     => 'synonym',
+            'synonyms' => array('San Francisco', 'SF'),
+        ), $synonym);
     }
 
     public function testSynonymsExport()


### PR DESCRIPTION
`initSynonymBrowser` was renamed `initSynonymIterator` few weeks back, unfortunately backward compat' was not preserved: https://github.com/algolia/algoliasearch-client-php/commit/f2681ea9629581857ed0feca3073977f490c49dc

This pull request aims to restore backward compatibility.