### PR TITLE
Set write hosts when using Places

### DIFF
--- a/src/AlgoliaSearch/ClientContext.php
+++ b/src/AlgoliaSearch/ClientContext.php
@@ -109,7 +109,7 @@ class ClientContext
 
         if ($this->readHostsArray == null || count($this->readHostsArray) == 0) {
             $this->readHostsArray = $this->getDefaultReadHosts($placesEnabled);
-            $this->writeHostsArray = $this->getDefaultWriteHosts();
+            $this->writeHostsArray = $this->getDefaultWriteHosts($placesEnabled);
         }
 
         if (($this->applicationID == null || mb_strlen($this->applicationID) == 0) && $placesEnabled === false) {
@@ -167,10 +167,24 @@ class ClientContext
     }
 
     /**
+     * @param bool $placesEnabled
+     *
      * @return array
      */
-    private function getDefaultWriteHosts()
+    private function getDefaultWriteHosts($placesEnabled)
     {
+        if ($placesEnabled) {
+            $hosts = array(
+                'places-1.algolianet.com',
+                'places-2.algolianet.com',
+                'places-3.algolianet.com',
+            );
+            shuffle($hosts);
+            array_unshift($hosts, 'places.algolia.net');
+
+            return $hosts;
+        }
+
         $hosts = array(
             $this->applicationID.'-1.algolianet.com',
             $this->applicationID.'-2.algolianet.com',

--- a/tests/AlgoliaSearch/Tests/InitPlacesTest.php
+++ b/tests/AlgoliaSearch/Tests/InitPlacesTest.php
@@ -3,6 +3,8 @@
 namespace AlgoliaSearch\Tests;
 
 use AlgoliaSearch\Client;
+use AlgoliaSearch\ClientContext;
+use ReflectionObject;
 
 class InitPlacesTest extends AlgoliaSearchTestCase
 {
@@ -36,5 +38,22 @@ class InitPlacesTest extends AlgoliaSearchTestCase
         $results = $index->search('');
         $this->assertArrayHasKey('nbHits', $results);
         $this->assertGreaterThan(0, $results['nbHits']);
+    }
+
+    public function testPlacesHostsAreCorrect()
+    {
+        $placesContext = new ClientContext(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'), null, true);
+
+        $refl = new ReflectionObject($placesContext);
+        $readHostsProperty = $refl->getProperty('readHostsArray');
+        $writeHostsProperty = $refl->getProperty('writeHostsArray');
+        $readHostsProperty->setAccessible(true);
+        $writeHostsProperty->setAccessible(true);
+
+        $readHosts = $readHostsProperty->getValue($placesContext);
+        $writeHosts = $writeHostsProperty->getValue($placesContext);
+
+        $this->assertArraySubset(array('places-dsn.algolia.net'), $readHosts);
+        $this->assertArraySubset(array('places.algolia.net'), $writeHosts);
     }
 }


### PR DESCRIPTION
Currently, if places is enabled, we set special read hosts but not write hosts. `appID-dsn` and such don't exists, we also need to set special hosts.

`places-dsn.algolia.net` will allow access to a read-only app, `places.algolia.net` must be used instead.

Note that you can't index data into a Places app but you may want to create API keys.

- [x] Set write hosts for places
- [x] Add tests