### PR TITLE
"Remove" $objectIDKey

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -172,9 +172,19 @@ class Index
      *
      * @return mixed
      */
-    public function addObjects($objects, $objectIDKey = 'objectID')
+    public function addObjects($objects, $objectIDKeyLegacy = 'objectID')
     {
-        $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
+
+        $objectIDKey = 'objectID';
+        if (is_string($objectIDKeyLegacy)) {
+            $objectIDKey = $objectIDKeyLegacy;
+        }
+
+        $requestHeaders = array();
+        $nbArgs = func_num_args();
+        if ($nbArgs > 1) {
+            $requestHeaders = is_array(func_get_arg($nbArgs-1)) ? func_get_arg($nbArgs-1) : array();
+        }
 
         $requests = $this->buildBatch('addObject', $objects, true, $objectIDKey);
 
@@ -307,14 +317,27 @@ class Index
      * Partially Override the content of several objects.
      *
      * @param array  $objects           contains an array of objects to update (each object must contains a objectID attribute)
-     * @param string $objectIDKey
+     * @param string $objectIDKey       This parameter is deprecated and should not be used
      * @param bool   $createIfNotExists
      *
      * @return mixed
      */
-    public function partialUpdateObjects($objects, $objectIDKey = 'objectID', $createIfNotExists = true)
+    public function partialUpdateObjects($objects, $createIfNotExistsOrObjectIDKeyLegacy = 'objectID', $createIfNotExistsLegacy = true)
     {
-        $requestHeaders = func_num_args() === 4 && is_array(func_get_arg(3)) ? func_get_arg(3) : array();
+        if (is_bool($createIfNotExistsOrObjectIDKeyLegacy)) {
+            $createIfNotExists = $createIfNotExistsOrObjectIDKeyLegacy;
+            $objectIDKey = 'objectID';
+        } elseif (is_string($createIfNotExistsOrObjectIDKeyLegacy)) {
+            $createIfNotExists = $createIfNotExistsLegacy;
+            $objectIDKey = $createIfNotExistsOrObjectIDKeyLegacy;
+        }
+
+        $requestHeaders = array();
+        $nbArgs = func_num_args();
+        if ($nbArgs > 2) {
+            $requestHeaders = is_array(func_get_arg($nbArgs-1)) ? func_get_arg($nbArgs-1) : array();
+        }
+
         if ($createIfNotExists) {
             $requests = $this->buildBatch('partialUpdateObject', $objects, true, $objectIDKey);
         } else {
@@ -327,15 +350,24 @@ class Index
     /**
      * Override the content of object.
      *
-     * @param array  $object      contains the object to save, the object must contains an objectID attribute
-     *                            or attribute specified in $objectIDKey considered as objectID
-     * @param string $objectIDKey
+     * @param array  $object        contains the object to save, the object must contains an objectID attribute
+     *                              or attribute specified in $objectIDKey considered as objectID
+     * @param string $objectIDKey   This parameter is deprecated and should not be used
      *
      * @return mixed
      */
-    public function saveObject($object, $objectIDKey = 'objectID')
+    public function saveObject($object, $objectIDKeyLegacy = 'objectID')
     {
-        $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
+        $objectIDKey = 'objectID';
+        if (is_string($objectIDKeyLegacy)) {
+            $objectIDKey = $objectIDKeyLegacy;
+        }
+
+        $requestHeaders = array();
+        $nbArgs = func_num_args();
+        if ($nbArgs > 1) {
+            $requestHeaders = is_array(func_get_arg($nbArgs-1)) ? func_get_arg($nbArgs-1) : array();
+        }
 
         return $this->client->request(
             $this->context,
@@ -353,14 +385,23 @@ class Index
     /**
      * Override the content of several objects.
      *
-     * @param array  $objects     contains an array of objects to update (each object must contains a objectID attribute)
-     * @param string $objectIDKey
+     * @param array  $objects       contains an array of objects to update (each object must contains a objectID attribute)
+     * @param string $objectIDKey   This parameter is deprecated and should not be used
      *
      * @return mixed
      */
-    public function saveObjects($objects, $objectIDKey = 'objectID')
+    public function saveObjects($objects, $objectIDKeyLegacy = 'objectID')
     {
-        $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
+        $objectIDKey = 'objectID';
+        if (is_string($objectIDKeyLegacy)) {
+            $objectIDKey = $objectIDKeyLegacy;
+        }
+
+        $requestHeaders = array();
+        $nbArgs = func_num_args();
+        if ($nbArgs > 1) {
+            $requestHeaders = is_array(func_get_arg($nbArgs-1)) ? func_get_arg($nbArgs-1) : array();
+        }
 
         $requests = $this->buildBatch('updateObject', $objects, true, $objectIDKey);
 

--- a/tests/AlgoliaSearch/Tests/IndexTest.php
+++ b/tests/AlgoliaSearch/Tests/IndexTest.php
@@ -57,4 +57,53 @@ class IndexTest extends AlgoliaSearchTestCase
         $results = $this->index->search('');
         $this->assertEquals(1, $results['nbHits']);
     }
+
+    public function testAddObjectsWithLegacySignature()
+    {
+        $res = $this->index->addObjects(
+            array(array(
+                'note' => 'this object should map `alpha` to the objectID',
+                'alpha' => 'primary-key-1',
+            )),
+            'alpha'
+        );
+        $this->index->waitTask($res['taskID']);
+
+        $res = $this->index->saveObjects(
+            array(array(
+                'note' => '`alpha` is the objectID',
+                'alpha' => 'primary-key-2',
+            )),
+            'alpha'
+        );
+        $this->index->waitTask($res['taskID']);
+
+        $res = $this->index->saveObject(
+            array(
+                'note' => '`alpha` is the objectID again',
+                'alpha' => 'primary-key-3',
+            ),
+            'alpha'
+        );
+        $this->index->waitTask($res['taskID']);
+
+        $results = $this->index->search('');
+        $this->assertEquals(3, $results['nbHits']);
+
+        foreach ($results['hits'] as $hit) {
+            $this->assertEquals($hit['objectID'], $hit['alpha']);
+        }
+
+        $res = $this->index->partialUpdateObjects(
+            array(array(
+                'extra' => 'this object should have `extra` and `note` attributes',
+                'alpha' => 'primary-key-1',
+            )),
+            'alpha'
+        );
+        $this->index->waitTask($res['taskID']);
+
+        $objects = $this->index->getObject('primary-key-1');
+        $this->assertArrayHasKey('note', $objects);
+    }
 }


### PR DESCRIPTION
Fix #369 

The parameter `$objectIDKey` only existed in the the PHP client. We decided to remove it to keep consistency with other client and ease documentation.

The signature of each method was kept for backward compatibility but should be used as if it was changed.

| Before                                                                                                     | After                                                                           |
|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
| addObjects($objects, $objectIDKey = 'objectID', $requestOptions = [])                                      | addObjects($objects, $requestOptions = [])                                      |
| partialUpdateObjects($objects, $objectIDKey = 'objectID', $createIfNotExists = true, $requestOptions = []) | partialUpdateObjects($objects, $createIfNotExists = true, $requestOptions = []) |
| saveObject($object, $objectIDKey = 'objectID', $requestOptions = [])                                       | saveObject($object, $requestOptions = [])                                       |
| saveObjects($objects, $objectIDKey = 'objectID', $requestOptions = [])                                     | saveObjects($objects, $requestOptions = [])                                     |


## TODO

- [x] Remove `$objectIDKey` parameter without breaking backward compat'
- [x] Add tests for BC and new signature