### PR TITLE
Add missing return statement in Client::isAlive() method

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -199,7 +199,7 @@ class Client
      */
     public function isAlive()
     {
-        $this->request(
+        return $this->request(
             $this->context,
             'GET',
             '/1/isalive',


### PR DESCRIPTION
Also, this method could maybe return a boolean value.
As we were not able to find the API doc for "isalive", we only added the return statement.