### PR TITLE
Fixes Laravel Scout link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ your PHP code.
 
 If you're a Symfony or Laravel user, you're probably looking for the following integrations:
 
-- **Laravel**: [Laravel Scout](/doc/api-client/laravel/algolia-and-scout/)
+- **Laravel**: [Laravel Scout](https://www.algolia.com/doc/api-client/laravel/algolia-and-scout/)
 - **Symfony**: [algolia/AlgoliaSearchBundle](https://github.com/algolia/AlgoliaSearchBundle)
 
 


### PR DESCRIPTION
This PR fixes the link of the Laravel integration on the `README.md` file. Currently, the link point to a 404 page.