### PR TITLE
Optimises method setConnectTimeout

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -128,15 +128,18 @@ class Client
      */
     public function setConnectTimeout($connectTimeout, $timeout = 30, $searchTimeout = 5)
     {
-        $version = curl_version();
-        $isPhpOld = version_compare(phpversion(), '5.2.3', '<');
-        $isCurlOld = version_compare($version['version'], '7.16.2', '<');
+        if ($this->context->connectTimeout < 1) {
+            $version = curl_version();
+            $isPhpSupported = version_compare(phpversion(), '5.2.3', '>=');
+            $isCurlSupported = version_compare($version['version'], '7.16.2', '>=');
 
-        if (($isPhpOld || $isCurlOld) && $this->context->connectTimeout < 1) {
-            throw new AlgoliaException(
-                "The timeout can't be a float with a PHP version less than 5.2.3 or a curl version less than 7.16.2"
-            );
+            if (! $isPhpSupported || ! $isCurlSupported) {
+                throw new AlgoliaException(
+                    "The timeout can't be a float with a PHP version less than 5.2.3 or a curl version less than 7.16.2"
+                );
+            }
         }
+
         $this->context->connectTimeout = $connectTimeout;
         $this->context->readTimeout = $timeout;
         $this->context->searchTimeout = $searchTimeout;

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -128,14 +128,12 @@ class Client
      */
     public function setConnectTimeout($connectTimeout, $timeout = 30, $searchTimeout = 5)
     {
-        if ($this->context->connectTimeout < 1) {
+        if ($connectTimeout < 1) {
             $version = curl_version();
-            $isPhpSupported = version_compare(phpversion(), '5.2.3', '>=');
-            $isCurlSupported = version_compare($version['version'], '7.16.2', '>=');
 
-            if (! $isPhpSupported || ! $isCurlSupported) {
+            if (version_compare($version['version'], '7.16.2', '<')) {
                 throw new AlgoliaException(
-                    "The timeout can't be a float with a PHP version less than 5.2.3 or a curl version less than 7.16.2"
+                    "The timeout can't be a float with a curl version less than 7.16.2"
                 );
             }
         }


### PR DESCRIPTION
Hey 👋

This PR addresses a small optimization on the method `setConnectTimeout` of the class `AlgoliaSearch \Client`. 

- Improves code readability.
- Improves **performance** avoiding methods such as `version_compare` and `curl_version` if the `$this->context->connectTimeout` is less than 1.