### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1782,6 +1782,10 @@ class Index
             $content['objectID'] = $objectID;
         }
 
+        if (! $content['objectID']) {
+            throw new AlgoliaException('Cannot save the rule because `objectID` must be set and non-empty.');
+        }
+
         return $this->client->request(
             $this->context,
             'PUT',

--- a/tests/AlgoliaSearch/Tests/RulesTest.php
+++ b/tests/AlgoliaSearch/Tests/RulesTest.php
@@ -41,6 +41,16 @@ class RulesTest extends AlgoliaSearchTestCase
     }
 
     /**
+     * @expectedException \AlgoliaSearch\AlgoliaException
+     */
+    public function testSaveRuleWithEmptyObjectID()
+    {
+        $rule = $this->getRuleStub('');
+        $this->index->saveRule('', $rule);
+    }
+
+
+    /**
      * @depends testSaveAndGetRule
      * @expectedException \AlgoliaSearch\AlgoliaException
      * @expectedExceptionMessage ObjectID does not exist


### PR DESCRIPTION
Preventing users to shoot themselves in the foot, following the issue with discovered in the Go client (see https://github.com/algolia/algoliasearch-client-go/issues/397).