### PR TITLE
fix(phpdoc): adapt phpdoc on search arguments

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -476,7 +476,7 @@ class Index
     /**
      * Search inside the index.
      *
-     * @param string $query the full text query
+     * @param string|null $query the full text query or null for disabling it
      * @param mixed $args (optional) if set, contains an associative array with query parameters:
      *                      - page: (integer) Pagination parameter used to select the page to retrieve.
      *                      Page is zero-based and defaults to 0. Thus, to retrieve the 10th page you need to set page=9


### PR DESCRIPTION
From my previous tests to search in an index.
When I only need to use the facets to search, and not the full query search, the `$query` parameter should be set to `null`, not an empty `string`.