### PR TITLE
Browse: Ensure cursor is passed in the body

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -1445,19 +1445,20 @@ class Index
                 $params[$key] = Json::encode($value);
             }
         }
-        if ($query != null) {
+        if ($query !== null) {
             $params['query'] = $query;
         }
-        if ($cursor != null) {
+
+        if ($cursor !== null) {
             $params['cursor'] = $cursor;
         }
 
         return $this->client->request(
             $this->context,
-            'GET',
+            empty($params) ? 'GET' : 'POST',
             '/1/indexes/'.$this->urlIndexName.'/browse',
-            $params,
             null,
+            $params,
             $this->context->readHostsArray,
             $this->context->connectTimeout,
             $this->context->readTimeout,

--- a/tests/AlgoliaSearch/Tests/BrowseIndexTest.php
+++ b/tests/AlgoliaSearch/Tests/BrowseIndexTest.php
@@ -30,6 +30,10 @@ class BrowseIndexTest extends AlgoliaSearchTestCase
         }
     }
 
+    /**
+     * This test is testing the legacy browse method
+     * See Index::_call() and Index::doBcBrowse()
+     */
     public function testBrowseIndex()
     {
         $task = $this->index->addObject(array('firstname' => 'Robin'));

--- a/tests/AlgoliaSearch/Tests/BrowseTest.php
+++ b/tests/AlgoliaSearch/Tests/BrowseTest.php
@@ -42,19 +42,25 @@ class BrowseTest extends AlgoliaSearchTestCase
         $this->index->waitTask($task['taskID']);
 
         $i = 0;
-
         foreach ($this->index->browse('') as $key => $value) {
             $i++;
         }
-
         $this->assertEquals(1500, $i);
 
         $i = 0;
-
         foreach ($this->index->browse('', array('numericFilters' => 'i<42')) as $key => $value) {
             $i++;
         }
-
         $this->assertEquals(42, $i);
+
+        // Test Browse with cursor
+        $response = $this->index->browseFrom(null, array());
+        $i = count($response['hits']);
+        $cursor = $response['cursor'];
+
+        $response = $this->index->browseFrom(null, array(), $cursor);
+        $i += count($response['hits']);
+
+        $this->assertEquals(1500, $i);
     }
 }


### PR DESCRIPTION
Cursor can get very long and exceed the max url size, for that reason we always pass it in the body of the request.

Note: In case there is no params (if you use $query = null) we fallback on a GET call since the API doesn't allow empty bodies for POST.