### PR TITLE
Fix PHP warning

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -847,6 +847,10 @@ class Index
         $aggregated_answer = $answers['results'][0];
         $aggregated_answer['disjunctiveFacets'] = array();
         for ($i = 1; $i < count($answers['results']); $i++) {
+            if (!isset($answers['results'][$i]['facets'])) {
+                continue;
+            }
+
             foreach ($answers['results'][$i]['facets'] as $key => $facet) {
                 $aggregated_answer['disjunctiveFacets'][$key] = $facet;
                 if (!in_array($key, $disjunctive_refinements)) {


### PR DESCRIPTION
This PR fixes `E_WARNING: Invalid argument supplied for foreach()` here : https://github.com/algolia/algoliasearch-client-php/blob/master/src/AlgoliaSearch/Index.php#L850

In some cases I don't have the `facets` key :

![image](https://user-images.githubusercontent.com/1501825/40297297-a14b2112-5cdf-11e8-9eeb-017ef86fdf9a.png)
