### PR TITLE
Introducing AB Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## Change Log
 
-### Unreleased
+### UNRELEASED
 
 <Contributors, please add your changes below this line>
+
+* Introduce AB Testing feature - PR [#408](https://github.com/algolia/algoliasearch-client-php/pull/#408)
+    List/Create/Stop/Delete AB Tests programmatically
+    Introduce new Analytics object, wrapper around the
+    [Analytics API](https://www.algolia.com/doc/rest-api/analytics/) (more methods to come).
 
 * 2 methods about taskID initially available in the `Index` moved to the `Client`. 
     You could get some taskID from the engine without necessarily have an instance of Index, 
@@ -50,7 +55,6 @@ https://blog.algolia.com/travis-encrypted-variables-external-contributions/
     Cursor can become so long that the generated URL fails (error HTTP 414).
 
 - Chore: Add PHP version to the UserAgent
-
 
 ### 1.25.1
 

--- a/src/AlgoliaSearch/Analytics.php
+++ b/src/AlgoliaSearch/Analytics.php
@@ -14,11 +14,10 @@ class Analytics
         $this->client = $client;
     }
 
-    public function getABTests($params = array(
-        'offset' => 0,
-        'limit' => 10,
-    ))
+    public function getABTests($params = array())
     {
+        $params += array('offset' => 0, 'limit' => 10);
+
         return $this->request('GET', '/2/abtests', $params);
     }
 
@@ -57,6 +56,11 @@ class Analytics
         }
 
         return $this->request('DELETE', sprintf('/2/abtests/%s', urlencode($abTestID)));
+    }
+
+    public function waitTask($indexName, $taskID, $timeBeforeRetry = 100, $requestHeaders = array())
+    {
+        $this->client->waitTask($indexName, $taskID, $timeBeforeRetry, $requestHeaders);
     }
 
     protected function request(

--- a/src/AlgoliaSearch/Analytics.php
+++ b/src/AlgoliaSearch/Analytics.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace AlgoliaSearch;
+
+class Analytics
+{
+    /**
+     * @var \AlgoliaSearch\Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function listABTests($params = array(
+        'offset' => 0,
+        'limit' => 10,
+    ))
+    {
+        return $this->request('GET', '/2/abtests', $params);
+    }
+
+    public function getABTest($abTestID)
+    {
+        if (!$abTestID) {
+            throw new AlgoliaException('Cannot retrieve ABTest because the abtestID is invalid.');
+        }
+
+        return $this->request('GET', sprintf('/2/abtests/%s', urlencode($abTestID)));
+    }
+
+    public function addABTest($abTest)
+    {
+        return $this->request(
+            'POST',
+            '/2/abtests',
+            array(),
+            $abTest
+        );
+    }
+
+    public function stopABTest($abTestID)
+    {
+        if (!$abTestID) {
+            throw new AlgoliaException('Cannot retrieve ABTest because the abtestID is invalid.');
+        }
+
+        return $this->request('POST', sprintf('/2/abtests/%s/stop', urlencode($abTestID)));
+    }
+
+    public function deleteABTest($abTestID)
+    {
+        if (!$abTestID) {
+            throw new AlgoliaException('Cannot retrieve ABTest because the abtestID is invalid.');
+        }
+
+        return $this->request('DELETE', sprintf('/2/abtests/%s', urlencode($abTestID)));
+    }
+
+    protected function request(
+        $method,
+        $path,
+        $params = array(),
+        $data = array()
+    ) {
+        return $this->client->request(
+            $this->client->getContext(),
+            $method,
+            $path,
+            $params,
+            $data,
+            array('analytics.algolia.com'),
+            $this->client->getContext()->connectTimeout,
+            $this->client->getContext()->readTimeout
+        );
+    }
+}

--- a/src/AlgoliaSearch/Analytics.php
+++ b/src/AlgoliaSearch/Analytics.php
@@ -14,7 +14,7 @@ class Analytics
         $this->client = $client;
     }
 
-    public function listABTests($params = array(
+    public function getABTests($params = array(
         'offset' => 0,
         'limit' => 10,
     ))

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -716,6 +716,11 @@ class Client
         return new Index($this->context, $this, $indexName);
     }
 
+    public function initAnalytics()
+    {
+        return new Analytics($this);
+    }
+
     /**
      * List all existing API keys with their associated ACLs.
      *
@@ -1327,9 +1332,14 @@ class Client
             return;
         }
 
-        $answer = Json::decode($response, true);
         $context->releaseMHandle($curlHandle);
         curl_close($curlHandle);
+
+        if ($http_status == 204) {
+            return '';
+        }
+
+        $answer = Json::decode($response, true);
 
         if (intval($http_status / 100) == 4) {
             throw new AlgoliaException(isset($answer['message']) ? $answer['message'] : $http_status.' error', $http_status);

--- a/src/AlgoliaSearch/Json.php
+++ b/src/AlgoliaSearch/Json.php
@@ -19,6 +19,8 @@ class Json
     public static function decode($json, $assoc = false, $depth = 512)
     {
         $value = json_decode($json, $assoc, $depth);
+        if (null === $value)
+            print_r($json);
 
         self::checkError();
 

--- a/tests/AlgoliaSearch/Tests/AnalyticsTest.php
+++ b/tests/AlgoliaSearch/Tests/AnalyticsTest.php
@@ -24,8 +24,8 @@ class AnalyticsTest extends AlgoliaSearchTestCase
 
     public function testListABTests()
     {
-        $this->analytics->listABTests(array('offset' => 1, 'limit' => 2));
-        $abTests = $this->analytics->listABTests();
+        $this->analytics->getABTests(array('offset' => 1, 'limit' => 2));
+        $abTests = $this->analytics->getABTests();
 
         $this->assertEquals(count($abTests['abtests']), $abTests['count']);
     }
@@ -89,7 +89,7 @@ class AnalyticsTest extends AlgoliaSearchTestCase
 
     private function guessABTestID($indexName)
     {
-        $list = $this->analytics->listABTests(array('limit' => 1000));
+        $list = $this->analytics->getABTests(array('limit' => 1000));
         foreach ($list['abtests'] as $ab) {
             if ($ab['variants'][0]['index'] == $indexName) {
                 return $ab['abtestID'];

--- a/tests/AlgoliaSearch/Tests/AnalyticsTest.php
+++ b/tests/AlgoliaSearch/Tests/AnalyticsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace AlgoliaSearch\Tests;
+
+use AlgoliaSearch\AlgoliaException;
+use AlgoliaSearch\Client;
+
+class AnalyticsTest extends AlgoliaSearchTestCase
+{
+    /** @var \AlgoliaSearch\Analytics */
+    private $analytics;
+
+    protected function setUp()
+    {
+        $client = new Client(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_API_KEY'));
+        $this->analytics = $client->initAnalytics();
+
+        $this->indexName = $this->safe_name('àlgol?à-php-ABTest-tmp');
+        $index = $client->initIndex($this->indexName);
+        $res = $index->addObject(['record' => 'I need this index']);
+        $res = $index->setSettings(['replicas' => [$this->indexName.'-alt']]);
+        $index->waitTask($res['taskID']);
+    }
+
+    public function testListABTests()
+    {
+        $this->analytics->listABTests(array('offset' => 1, 'limit' => 2));
+        $abTests = $this->analytics->listABTests();
+
+        $this->assertEquals(count($abTests['abtests']), $abTests['count']);
+    }
+
+    public function testAddGetAndDeleteABTest()
+    {
+        $abTestToAdd = $this->getABTest('Some test');
+
+        try {
+            $response = $this->analytics->addABTest($abTestToAdd);
+            $abTestID = $response['abtestID'];
+        } catch (AlgoliaException $e) {
+            $idToDelete = $this->guessABTestID($this->indexName);
+            $this->analytics->deleteABTest($idToDelete);
+            sleep(3);
+
+            $response = $this->analytics->addABTest($abTestToAdd);
+            $abTestID = $response['abtestID'];
+        }
+
+        sleep(2); // Just in case
+
+        $abTest = $this->analytics->getABTest($abTestID);
+        $this->assertEquals($abTest['abtestID'], $abTestID);
+        $this->assertArraySubset($abTestToAdd['variants'][0], $abTest['variants'][0]);
+        unset($abTestToAdd['variants']);
+
+        unset($abTestToAdd['endAt']); // Because time is modified by the API
+        $this->assertArraySubset($abTestToAdd, $abTest);
+    }
+
+    /**
+     * @dataProvider dataInvalidAbTest
+     * @expectedException \AlgoliaSearch\AlgoliaException
+     */
+    public function testAddInvalidABTest($abTest)
+    {
+        $this->analytics->addABTest($abTest);
+    }
+
+    public function dataInvalidAbTest()
+    {
+        return array(
+            array(array()),
+            array(array('name' => 'invalid AB Test')),
+            array(array('variants' => array())),
+        );
+    }
+
+    public function getABTest($name)
+    {
+        return array(
+            "name" => $name,
+            "variants" => array(
+                array("index" => $this->indexName,"trafficPercentage" => 90, "description" =>  ""),
+                array("index" => $this->indexName."-alt","trafficPercentage" => 10),
+            ),
+            "endAt" =>  (new \DateTime('tomorrow'))->format('Y-m-d\TH:i:s\Z'),
+        );
+    }
+
+    private function guessABTestID($indexName)
+    {
+        $list = $this->analytics->listABTests(array('limit' => 1000));
+        foreach ($list['abtests'] as $ab) {
+            if ($ab['variants'][0]['index'] == $indexName) {
+                return $ab['abtestID'];
+            }
+        }
+
+        return null; // this will fail later
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Need Doc update   | yes


## What was changed

Algolia introduced (in Beta) a new feature to create AB Test directly from your dashboard. This PR aims to make it easier to manage ABTests programatically.

I'd like to introduce a new _"first-class citizen object"_ , along with `Client` and `Index`, named `Analytics`. More method should be added to the Analytics object if we validate it.

The Analytics API doc can be found here: chttps://www.algolia.com/doc/rest-api/analytics/. 

## New methods

```php
$analytics->getABTests(); // It's not called `list`, because it's paginated
$analytics->addABTest($abTestDefinition); // It's not called `save` because you can't set the abtestID
$analytics->getABTest($abTestID);
$analytics->stopABTest($abTestID);
$analytics->deleteABTest($abTestID);
```

## Full example

### Setup your index

```php
$client = new \AlgoliaSearch\Client(getenv('ALGOLIA_APP_ID'), getenv('ALGOLIA_API_KEY'));

$index = $client->initIndex('products');

$index->setSettings([
    'replicas' => [
        'products-alt'
    ],
    'customRanking' => [
        'desc(popularity)',
        'asc(price)',
    ]
], true);

$alt = $client->initIndex('products-alt');
$alt->setSettings([
    'customRanking' => [
        'desc(nb_comments_ratio)',
        'desc(popularity)',
    ]
]);

$index->addObjects($allMyProducts);
```

### Create AB Test scenario

```php
$analytics = $client->initAnalytics();

$response = $analytics->addABTest([
    "name" => $name,
    "variants" => [
        [
            "index" => "products",
            "trafficPercentage" => 70,
            "description" =>  "popular and cheaper",
        ], 
        [
            "index" => "products-alt",
            "trafficPercentage" => 30,
            "description" =>  "popular and cheaper",
        ],
    ],
    "endAt" =>  (new \DateTime('next month'))->format('Y-m-d\TH:i:s\Z'), // Notice the format
]);

// Wait until the task is complete if necessary
$analytics->waitTask($response['index'], $response['taskID']);
```

### Search (as you normally would)

Our engine takes care of forwarding the request to the index, according to the `trafficPercentage` defined.

```php
$index->search('joe');
```

## Note to other maintainers

* Remember to activate ABTest for your app used by Travis
* Most endpoints requires either `setSettings` or `Analytics` ACL so it should be testable with the API Key Dealer