### PR TITLE
feat(client): Expose waitTask in the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 <Contributors, please add your changes below this line>
 
+* 2 methods about taskID initially available in the `Index` moved to the `Client`. 
+    You could get some taskID from the engine without necessarily have an instance of Index, 
+    instead of instanciating an index that you won't need, you can now call waitTask and getTaskStatus on the client.
+    The original methods on the index still work are **not** deprecated.
+ 
+     ```php
+     $client->waitTask($indexName, $taskID)
+     $client->getTaskStatus($indexName, $taskID)
+    ```
 
 ### 1.26.0
 

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -231,6 +231,32 @@ class Client
         $this->context->setExtraHeader($key, $value);
     }
 
+    public function waitTask($indexName, $taskID, $timeBeforeRetry = 100, $requestHeaders = array())
+    {
+        while (true) {
+            $res = $this->getTaskStatus($indexName, $taskID, $requestHeaders);
+            if ($res['status'] === 'published') {
+                return $res;
+            }
+            usleep($timeBeforeRetry * 1000);
+        }
+    }
+
+    public function getTaskStatus($indexName, $taskID, $requestHeaders = array())
+    {
+        return $this->request(
+            $this->context,
+            'GET',
+            sprintf('/1/indexes/%s/task/%s', urlencode($indexName), urlencode($taskID)),
+            null,
+            null,
+            $this->context->readHostsArray,
+            $this->context->connectTimeout,
+            $this->context->readTimeout,
+            $requestHeaders
+        );
+    }
+
     /**
      * This method allows to query multiple indexes with one API call.
      *

--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -942,13 +942,7 @@ class Index
     {
         $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
 
-        while (true) {
-            $res = $this->getTaskStatus($taskID, $requestHeaders);
-            if ($res['status'] === 'published') {
-                return $res;
-            }
-            usleep($timeBeforeRetry * 1000);
-        }
+        $this->client->waitTask($this->indexName, $taskID, $timeBeforeRetry, $requestHeaders);
     }
 
     /**
@@ -963,17 +957,7 @@ class Index
     {
         $requestHeaders = func_num_args() === 2 && is_array(func_get_arg(1)) ? func_get_arg(1) : array();
 
-        return $this->client->request(
-            $this->context,
-            'GET',
-            '/1/indexes/'.$this->urlIndexName.'/task/'.$taskID,
-            null,
-            null,
-            $this->context->readHostsArray,
-            $this->context->connectTimeout,
-            $this->context->readTimeout,
-            $requestHeaders
-        );
+        return $this->client->getTaskStatus($this->indexName, $taskID, $requestHeaders);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes (not sure)


## What was changed

2 methods about taskID initially available in the `Index` moved to the `Client`. The original methods on the index still work are **not** deprecated.

```php
// New 🎉
$client->waitTask($indexName, $taskID, $timeBeforeRetry = 100, $requestHeaders = array())
$client->getTaskStatus($indexName, $taskID, $requestHeaders = array())

// Still available
$index->waitTask($taskID, $timeBeforeRetry = 100, $requestHeaders = array())
$index->getTaskStatus($taskID, $requestHeaders = array())
```

**NOTE**: The `$timeBeforeRetry` parameter is kept even if it doesn't exist in other clients. I believe it's a powerful feature.

## Why it was changed

You could get some taskID from the engine without necessarily having an instance of Index. Instead of instantiating an index that you won't need, you can now call `waitTask` and `getTaskStatus` on the client.

* It will be very useful for the new Analytics object (see https://github.com/algolia/algoliasearch-client-php/pull/408)
* We're planning to merge https://github.com/algolia/algoliasearch-client-php/pull/295 (and port it to all clients). Adding multipleObjects will be easier to use if waitTask lives in the Client.
* It was also discussed before for the Django integration ([here](https://github.com/algolia/algoliasearch-django/pull/258)).
