### PR TITLE
Set json encode unescaped unicode as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <Contributors, please add your changes below this line>
 
+* Sets the JSON encode method to not escape unicode characters by default
+
 
 ### 1.27.0
 

--- a/src/AlgoliaSearch/Json.php
+++ b/src/AlgoliaSearch/Json.php
@@ -7,7 +7,7 @@ namespace AlgoliaSearch;
  */
 class Json
 {
-    public static function encode($value, $options = 0)
+    public static function encode($value, $options = JSON_UNESCAPED_UNICODE)
     {
         $json = json_encode($value, $options);
 

--- a/tests/AlgoliaSearch/Tests/JsonTest.php
+++ b/tests/AlgoliaSearch/Tests/JsonTest.php
@@ -39,4 +39,13 @@ class JsonTest extends AlgoliaSearchTestCase
 
         Json::encode($malformedString);
     }
+
+    public function testMultiByteString()
+    {
+        $multiByteString = '검색 엔진';
+
+        $json = Json::encode($multiByteString);
+
+        $this->assertEquals('"검색 엔진"', $json);
+    }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | no


## What was changed

The `Json::encode` method now has the `JSON_UNESCAPED_UNICODE` option enabled by default

## Why it was changed

The reason for this change is that when encoding multi byte strings the size of the JSON object is significantly larger and starts to cause errors with max record sizes.

For example:

`strlen('검색 엔진')` => 13
**pre-change**: `strlen(Json::encode('검색 엔진'))` => 27
**post-change**: `strlen(Json::encode('검색 엔진'))` => 15
