### PR TITLE
Describe actual behavior of scoped copy operation

### DIFF
--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -404,7 +404,7 @@ class Client
     }
 
     /**
-     * Copy an existing index and define what to copy along with records:
+     * Copy an existing index and define what to copy instead of records:
      *  - settings
      *  - synonyms
      *  - query rules
@@ -413,7 +413,7 @@ class Client
      *
      * @param string $srcIndexName the name of index to copy.
      * @param string $dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overwritten if it already exist).
-     * @param array $scope Resource to copy along with records: 'settings', 'rules', 'synonyms'
+     * @param array $scope Resource to copy instead of records: 'settings', 'rules', 'synonyms'
      * @param array $requestHeaders
      * @return mixed
      */


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## What was changed

some comments

## Why it was changed

The comments imply that records will be copied if you specify a scope.
This is not the behavior I observe, and this is also not what is
documented on https://www.algolia.com/doc/rest-api/search/#copymove-index :

> Keep in mind that when you use the scopes parameter, you will no
longer be copying records (objects) but only the specified scopes.

It might have been true in the past, but it is currently not the case.
