### PR TITLE
Introduce custom PSR-4 autoload if not using composer

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Based on https://www.php-fig.org/psr/psr-4/examples/
+ */
+spl_autoload_register(function ($class) {
+
+    // project-specific namespace prefix
+    $prefix = 'Algolia\\AlgoliaSearch\\';
+
+    // base directory for the namespace prefix
+    $base_dir = __DIR__ . '/src/';
+
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        // no, move to the next registered autoloader
+        return;
+    }
+
+    // get the relative class name
+    $relative_class = substr($class, $len);
+
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    dump($file);
+
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## What was changed

Adding a custom autoload. If you don't use composer, you can require the new `autoload.php`.

Example:
```php
<?php

require 'lib/algolia/autoload.php'; # example path

$client  = Client::create();
```

## Why it was changed

Some older projects (WordPress, Drupal 7, and such) aren't using composer for autoloading). For v1, they rely on a file that require all the existing file: [`algoliasearch.php`](https://github.com/algolia/algoliasearch-client-php/blob/1.27.0/algoliasearch.php).

This new file sets a custom autoloader instead of requiring all the things.