### PR TITLE
Introduce BatchIterator

### DIFF
--- a/src/Interfaces/ClientConfigInterface.php
+++ b/src/Interfaces/ClientConfigInterface.php
@@ -23,4 +23,6 @@ interface ClientConfigInterface
     public function getWaitTaskMaxRetry();
 
     public function getWaitTaskTimeBeforeRetry();
+
+    public function getBatchSize();
 }

--- a/src/Iterators/AbstractBatchIterator.php
+++ b/src/Iterators/AbstractBatchIterator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Iterators;
+
+abstract class AbstractBatchIterator implements \Iterator
+{
+    protected $batch;
+
+    protected $currentBatchNumber = 0;
+
+    abstract public function getBatch();
+
+    public function current()
+    {
+        return $this->batch;
+    }
+
+    public function next()
+    {
+        $this->currentBatchNumber++;
+        $this->batch = $this->getBatch();
+    }
+
+    public function key()
+    {
+        return $this->currentBatchNumber;
+    }
+
+    public function valid()
+    {
+        if (0 === $this->currentBatchNumber) {
+            $this->batch = $this->getBatch();
+        }
+
+        return (is_array($this->batch) || $this->batch instanceof \JsonSerializable)
+            && !empty($this->batch);
+    }
+
+    public function rewind()
+    {
+        $this->currentBatchNumber = 0;
+        $this->batch = null;
+    }
+ }

--- a/src/Iterators/AbstractBatchIterator.php
+++ b/src/Iterators/AbstractBatchIterator.php
@@ -2,7 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Iterators;
 
-abstract class AbstractBatchIterator implements \Iterator
+use Iterator;
+
+abstract class AbstractBatchIterator implements Iterator
 {
     protected $batch;
 

--- a/src/Iterators/ArrayBatchIterator.php
+++ b/src/Iterators/ArrayBatchIterator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Iterators;
+
+use Traversable;
+
+class ArrayBatchIterator extends AbstractBatchIterator
+{
+    /**
+     * The items to be sliced into batches.
+     *
+     * @var array
+     */
+    private $items;
+
+    /**
+     * The number of items per batch.
+     *
+     * @var int
+     */
+    private $itemsPerBatch;
+
+    /**
+     * Create a new ArrayBatchIterator.
+     *
+     * @param mixed $items
+     * @param int $itemsPerBatch
+     */
+    public function __construct($items, $itemsPerBatch = 200)
+    {
+        $this->items = $this->getArrayableItems($items);
+        $this->itemsPerBatch = (int)$itemsPerBatch;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBatch()
+    {
+        $offset = $this->currentBatchNumber * $this->itemsPerBatch;
+
+        $length = $offset + $this->itemsPerBatch;
+
+        return array_slice($this->items, $offset, $length);
+    }
+
+    /**
+     * Results array of items from the provided value.
+     *
+     * @param  mixed $items
+     * @return array
+     */
+    private function getArrayableItems($items)
+    {
+        if (! is_array($items)) {
+            $items = (array)$items;
+        } elseif ($items instanceof Traversable) {
+            $items = iterator_to_array($items);
+        }
+        return array_values((array)$items);
+    }
+}

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -16,6 +16,8 @@ class ClientConfig implements ClientConfigInterface
     private $defaultWriteTimeout = 5;
     private $defaultConnectTimeout = 2;
 
+    private $defaultBatchSize = 100;
+
     public function __construct(array $config = array())
     {
         $config += $this->getDefaultConfig();
@@ -52,6 +54,7 @@ class ClientConfig implements ClientConfigInterface
             'connectTimeout' => $this->defaultConnectTimeout,
             'waitTaskTimeBeforeRetry' => $this->defaultWaitTaskTimeBeforeRetry,
             'waitTaskMaxRetry' => $this->defaultWaitTaskMaxRetry,
+            'batchSize' => $this->defaultBatchSize,
         );
     }
 
@@ -147,6 +150,18 @@ class ClientConfig implements ClientConfigInterface
     public function setWaitTaskTimeBeforeRetry($time)
     {
         $this->config['waitTaskTimeBeforeRetry'] = $time;
+
+        return $this;
+    }
+
+    public function getBatchSize()
+    {
+        return $this->config['batchSize'];
+    }
+
+    public function setBatchSize($batchSize)
+    {
+        $this->config['batchSize'] = (int)$batchSize;
 
         return $this;
     }

--- a/tests/FakeBatchIterator.php
+++ b/tests/FakeBatchIterator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use Algolia\AlgoliaSearch\Iterators\AbstractBatchIterator;
+
+class FakeBatchIterator extends AbstractBatchIterator
+{
+    private $data = array();
+    private $perPage;
+
+    public function __construct()
+    {
+        foreach (range(1000, 1100) as $id) {
+            $this->data[] = array(
+                'objectID' => $id,
+                'someAttribute' => 'text'
+            );
+        }
+        $this->perPage = 10;
+    }
+
+    public function getBatch()
+    {
+        $start = $this->perPage * $this->currentBatchNumber;
+
+        return array_slice($this->data, $start, $this->perPage);
+    }
+}

--- a/tests/FakeBatchIterator.php
+++ b/tests/FakeBatchIterator.php
@@ -14,7 +14,7 @@ class FakeBatchIterator extends AbstractBatchIterator
         foreach (range(1000, 1100) as $id) {
             $this->data[] = array(
                 'objectID' => $id,
-                'someAttribute' => 'text'
+                'someAttribute' => 'iterator'
             );
         }
         $this->perPage = 10;

--- a/tests/GimmeTheRequestHttpClient.php
+++ b/tests/GimmeTheRequestHttpClient.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use Algolia\AlgoliaSearch\Http\HttpClientInterface;
+use Psr\Http\Message\RequestInterface;
+
+class GimmeTheRequestHttpClient implements HttpClientInterface
+{
+    private $actual;
+
+    public function __construct(HttpClientInterface $actual)
+    {
+        $this->actual = $actual;
+    }
+
+    public function createUri($uri)
+    {
+        return $this->actual->createUri($uri);
+    }
+
+    public function createRequest($method,
+                                  $uri,
+                                  array $headers = array(),
+                                  $body = null,
+                                  $protocolVersion = '1.1')
+    {
+        return $this->actual->createRequest($method, $uri, $headers, $body, $protocolVersion);
+    }
+
+    public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
+    {
+        return array(
+            'request' => $request,
+            'timeout' => $timeout,
+            'connectTimeout' => $connectTimeout,
+        );
+    }
+}

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Unit;
+
+use Algolia\AlgoliaSearch\Index;
+use Algolia\AlgoliaSearch\Internals\ApiWrapper;
+use Algolia\AlgoliaSearch\Support\ClientConfig;
+use Algolia\AlgoliaSearch\Support\Config;
+use Algolia\AlgoliaSearch\Tests\FakeBatchIterator;
+use Algolia\AlgoliaSearch\Tests\GimmeTheRequestHttpClient;
+use PHPUnit\Framework\TestCase;
+
+class IndexTest extends TestCase
+{
+    private $index;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->index = new Index(
+            'ìndexÑäme',
+            new ApiWrapper(
+                new GimmeTheRequestHttpClient(
+                    Config::getHttpClient()
+                ),
+                new ClientConfig('algoliaAppId', 'algoliaApiKey')
+            )
+        );
+    }
+
+    public function testBatchIterator()
+    {
+        $objects = new FakeBatchIterator();
+        $response = $this->index->saveObjects($objects);
+
+        $this->assertCount(11, $response);
+
+        $last = end($response);
+        $batch1 = (string) $last['request']->getBody();
+        $batch1 = json_decode($batch1, true);
+        $batch1 = $batch1['requests'];
+        $this->assertArraySubset(array(
+            'action' => 'addObject',
+            'body' => array(
+                'objectID' => 1100,
+                'someAttribute' => 'text',
+            ),
+        ), reset($batch1));
+    }
+}

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -29,7 +29,34 @@ class IndexTest extends TestCase
         );
     }
 
-    public function testBatchIterator()
+    public function testSaveObjectsWithArray()
+    {
+        $objects = array();
+        for ($i = 1; $i <= 100; $i++) {
+            $objects[] = array(
+                'objectID' => $i,
+                'someAttribute' => 'array'
+            );
+        }
+
+        $response = $this->index->saveObjects($objects);
+
+        $this->assertCount(1, $response);
+
+        $last = end($response);
+        $batch1 = (string)$last['request']->getBody();
+        $batch1 = json_decode($batch1, true);
+        $batch1 = $batch1['requests'];
+        $this->assertArraySubset(array(
+            'action' => 'addObject',
+            'body' => array(
+                'objectID' => 1,
+                'someAttribute' => 'array',
+            ),
+        ), reset($batch1));
+    }
+
+    public function testSaveObjectsWithIterator()
     {
         $objects = new FakeBatchIterator();
         $response = $this->index->saveObjects($objects);
@@ -44,7 +71,7 @@ class IndexTest extends TestCase
             'action' => 'addObject',
             'body' => array(
                 'objectID' => 1100,
-                'someAttribute' => 'text',
+                'someAttribute' => 'iterator',
             ),
         ), reset($batch1));
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | yes
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

`Index::saveObjects` can now take a `BatchIterator` instead of just an array of object. Using this iterator, you can index millions of records in just one line. The API client create a new http call, for each batch given by the iterator.

See example in `tests/`.

**Note that the return type of `saveObjects` is now an array of response from the API (one entry per batch).**

## What problem is this fixing?

If you want to reindex your entire database, you foten need to chunk it youself and call `Index::saveObjects` multiple time. With this abstract iterator, you can easily create an iterator to avoid loading everything in memory.