### PR TITLE
Refacto/merge config

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -15,14 +15,20 @@ final class Analytics
      */
     private $api;
 
-    public function __construct(ApiWrapper $api)
+    /**
+     * @var ClientConfig
+     */
+    private $config;
+
+    public function __construct(ApiWrapper $api, ClientConfig $config)
     {
         $this->api = $api;
+        $this->config = $config;
     }
 
     public static function create($appId = null, $apiKey = null)
     {
-        $config = new ClientConfig($appId, $apiKey);
+        $config = ClientConfig::create($appId, $apiKey);
         $config->setHosts(ClusterHosts::createForAnalytics());
 
         return static::createWithConfig($config);
@@ -35,7 +41,7 @@ final class Analytics
             $config
         );
 
-        return new static($apiWrapper);
+        return new static($apiWrapper, $config);
     }
 
     public function getABTests($params = array())

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,8 +36,11 @@ class Client implements ClientInterface
 
     public static function create($appId = null, $apiKey = null)
     {
-        $config = new ClientConfig($appId, $apiKey);
+        return static::createWithConfig(ClientConfig::create($appId, $apiKey));
+    }
 
+    public static function createWithConfig(ClientConfig $config)
+    {
         $apiWrapper = new ApiWrapper(
             Config::getHttpClient(),
             $config

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,11 +18,17 @@ class Client implements ClientInterface
      */
     protected $api;
 
+    /**
+     * @var ClientConfig
+     */
+    protected $config;
+
     protected static $client;
 
-    public function __construct(ApiWrapper $apiWrapper)
+    public function __construct(ApiWrapper $apiWrapper, ClientConfig $config)
     {
         $this->api = $apiWrapper;
+        $this->config = $config;
     }
 
     public static function get()
@@ -46,12 +52,12 @@ class Client implements ClientInterface
             $config
         );
 
-        return new static($apiWrapper);
+        return new static($apiWrapper, $config);
     }
 
     public function initIndex($indexName)
     {
-        return new Index($indexName, $this->api);
+        return new Index($indexName, $this->api, $this->config);
     }
 
     public function setExtraHeader($headerName, $headerValue)

--- a/src/Client.php
+++ b/src/Client.php
@@ -290,7 +290,8 @@ class Client implements ClientInterface
     public function waitForKeyAdded($key, $requestOptions = array())
     {
         $retry = 1;
-        $maxRetry = Config::$waitTaskRetry;
+        $maxRetry = $this->config->getWaitTaskMaxRetry();
+        $time = $this->config->getWaitTaskTimeBeforeRetry();
 
         do {
             try {
@@ -303,7 +304,7 @@ class Client implements ClientInterface
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * 100000); // 0.1 second
+            usleep($factor * $time); // 0.1 second
         } while ($retry < $maxRetry);
 
         throw new TaskTooLongException('The key '.substr($key, 0, 6)."... isn't added yet.");

--- a/src/Index.php
+++ b/src/Index.php
@@ -9,6 +9,7 @@ use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\Iterators\ObjectIterator;
 use Algolia\AlgoliaSearch\Iterators\RuleIterator;
 use Algolia\AlgoliaSearch\Iterators\SynonymIterator;
+use Algolia\AlgoliaSearch\Support\ClientConfig;
 use Algolia\AlgoliaSearch\Support\Config;
 use Algolia\AlgoliaSearch\Support\Helpers;
 
@@ -19,12 +20,18 @@ class Index implements IndexInterface
     /**
      * @var ApiWrapper
      */
-    private $api;
+    protected $api;
 
-    public function __construct($indexName, ApiWrapper $apiWrapper)
+    /**
+     * @var ClientConfig
+     */
+    protected $config;
+
+    public function __construct($indexName, ApiWrapper $apiWrapper, ClientConfig $config)
     {
         $this->indexName = $indexName;
         $this->api = $apiWrapper;
+        $this->config = $config;
     }
 
     public function getIndexName()

--- a/src/Index.php
+++ b/src/Index.php
@@ -416,7 +416,8 @@ class Index implements IndexInterface
     public function waitTask($taskId, $requestOptions = array())
     {
         $retry = 1;
-        $maxRetry = Config::$waitTaskRetry;
+        $maxRetry = $this->config->getWaitTaskMaxRetry();
+        $time = $this->config->getWaitTaskTimeBeforeRetry();
 
         do {
             $res = $this->getTask($taskId, $requestOptions);
@@ -427,7 +428,7 @@ class Index implements IndexInterface
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * 100000); // 0.1 second
+            usleep($factor * $time); // 0.1 second
         } while ($retry < $maxRetry);
 
         throw new TaskTooLongException();

--- a/src/Places.php
+++ b/src/Places.php
@@ -14,14 +14,20 @@ final class Places
      */
     private $api;
 
-    public function __construct(ApiWrapper $apiWrapper)
+    /**
+     * @var ClientConfig
+     */
+    private $config;
+
+    public function __construct(ApiWrapper $api, ClientConfig $config)
     {
-        $this->api = $apiWrapper;
+        $this->api = $api;
+        $this->config = $config;
     }
 
     public static function create($appId = null, $apiKey = null)
     {
-        $config = new ClientConfig($appId, $apiKey);
+        $config = ClientConfig::create($appId, $apiKey);
         $config->setHosts(ClusterHosts::createForPlaces());
 
         return static::createWithConfig($config);
@@ -34,7 +40,7 @@ final class Places
             $config
         );
 
-        return new static($apiWrapper);
+        return new static($apiWrapper, $config);
     }
 
     public function custom($method, $path, $requestOptions = array(), $hosts = null)

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -3,7 +3,7 @@
 namespace Algolia\AlgoliaSearch\RequestOptions;
 
 use Algolia\AlgoliaSearch\Support\ClientConfig;
-use Algolia\AlgoliaSearch\Support\Config;
+use Algolia\AlgoliaSearch\Support\UserAgent;
 
 class RequestOptionsFactory
 {
@@ -71,7 +71,7 @@ class RequestOptionsFactory
             'headers' => array(
                 'X-Algolia-Application-Id' => $this->config->getAppId(),
                 'X-Algolia-API-Key' => $this->config->getApiKey(),
-                'User-Agent' => Config::getUserAgent(),
+                'User-Agent' => UserAgent::get(),
             ),
             'query' => array(),
             'body' => array(),

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -13,7 +13,7 @@ class ClientConfig
     private $defaultWriteTimeout = 5;
     private $defaultConnectTimeout = 2;
 
-    public function __construct($config = array())
+    public function __construct(array $config = array())
     {
         $config += $this->getDefaultConfig();
 

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -13,9 +13,20 @@ class ClientConfig
     private $defaultWriteTimeout = 5;
     private $defaultConnectTimeout = 2;
 
-    public function __construct($appId = null, $apiKey = null)
+    public function __construct($config = array())
     {
-        $config = $this->getDefaultConfig();
+        $config += $this->getDefaultConfig();
+
+        if (null === $config['hosts']) {
+            $config['hosts'] = ClusterHosts::createFromAppId($config['appId']);
+        }
+
+        $this->config = $config;
+    }
+
+    public static function create($appId = null, $apiKey = null)
+    {
+        $config = array();
 
         if (null !== $appId) {
             $config['appId'] = $appId;
@@ -24,11 +35,7 @@ class ClientConfig
             $config['apiKey'] = $apiKey;
         }
 
-        if (null === $config['hosts']) {
-            $config['hosts'] = ClusterHosts::createFromAppId($config['appId']);
-        }
-
-        $this->config = $config;
+        return new static($config);
     }
 
     private function getDefaultConfig()

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -8,6 +8,11 @@ class ClientConfig
 {
     private $config;
 
+    private $defaultWaitTaskRetry = 100;
+    private $defaultReadTimeout = 5;
+    private $defaultWriteTimeout = 5;
+    private $defaultConnectTimeout = 2;
+
     public function __construct($appId = null, $apiKey = null)
     {
         $config = $this->getDefaultConfig();
@@ -32,10 +37,10 @@ class ClientConfig
             'appId' => getenv('ALGOLIA_APP_ID'),
             'apiKey' => getenv('ALGOLIA_API_KEY'),
             'hosts' => null,
-            'waitTaskRetry' => Config::$waitTaskRetry,
-            'readTimeout' => Config::getReadTimeout(),
-            'writeTimeout' => Config::getWriteTimeout(),
-            'connectTimeout' => Config::getConnectTimeout(),
+            'waitTaskRetry' => $this->defaultWaitTaskRetry,
+            'readTimeout' => $this->defaultReadTimeout,
+            'writeTimeout' => $this->defaultWriteTimeout,
+            'connectTimeout' => $this->defaultConnectTimeout,
         );
     }
 

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -8,7 +8,9 @@ class ClientConfig
 {
     private $config;
 
-    private $defaultWaitTaskRetry = 100;
+    private $defaultWaitTaskTimeBeforeRetry = 100000;
+    private $defaultWaitTaskMaxRetry = 30;
+
     private $defaultReadTimeout = 5;
     private $defaultWriteTimeout = 5;
     private $defaultConnectTimeout = 2;
@@ -44,10 +46,11 @@ class ClientConfig
             'appId' => getenv('ALGOLIA_APP_ID'),
             'apiKey' => getenv('ALGOLIA_API_KEY'),
             'hosts' => null,
-            'waitTaskRetry' => $this->defaultWaitTaskRetry,
             'readTimeout' => $this->defaultReadTimeout,
             'writeTimeout' => $this->defaultWriteTimeout,
             'connectTimeout' => $this->defaultConnectTimeout,
+            'waitTaskTimeBeforeRetry' => $this->defaultWaitTaskTimeBeforeRetry,
+            'waitTaskMaxRetry' => $this->defaultWaitTaskMaxRetry,
         );
     }
 
@@ -87,18 +90,6 @@ class ClientConfig
         return $this;
     }
 
-    public function getWaitTaskRetry()
-    {
-        return $this->config['waitTaskRetry'];
-    }
-
-    public function setWaitTaskRetry($waitTaskRetry)
-    {
-        $this->config['waitTaskRetry'] = $waitTaskRetry;
-
-        return $this;
-    }
-
     public function getReadTimeout()
     {
         return $this->config['readTimeout'];
@@ -131,6 +122,30 @@ class ClientConfig
     public function setConnectTimeout($connectTimeout)
     {
         $this->config['connectTimeout'] = $connectTimeout;
+
+        return $this;
+    }
+
+    public function getWaitTaskMaxRetry()
+    {
+        return $this->config['waitTaskMaxRetry'];
+    }
+
+    public function setWaitMaxTaskRetry($max)
+    {
+        $this->config['waitTaskMaxRetry'] = $max;
+
+        return $this;
+    }
+
+    public function getWaitTaskTimeBeforeRetry()
+    {
+        return $this->config['waitTaskTimeBeforeRetry'];
+    }
+
+    public function setWaitTaskTimeBeforeRetry($time)
+    {
+        $this->config['waitTaskTimeBeforeRetry'] = $time;
 
         return $this;
     }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -6,28 +6,7 @@ final class Config
 {
     const VERSION = '2.0.0';
 
-    private static $userAgent;
-    private static $customUserAgent = '';
-
     private static $httpClientConstructor;
-
-    public static function getUserAgent()
-    {
-        if (!static::$userAgent) {
-            static::$userAgent = 'PHP ('.str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION).'); ';
-            if (defined('HHVM_VERSION')) {
-                static::$userAgent .= '; HHVM ('.HHVM_VERSION.')';
-            }
-            static::$userAgent .= 'Algolia for PHP ('.self::VERSION.')';
-        }
-
-        return static::$userAgent.static::$customUserAgent;
-    }
-
-    public static function addCustomUserAgent($segment, $version)
-    {
-        static::$customUserAgent .= '; '.trim($segment, ' ').' ('.trim($version, ' ').')';
-    }
 
     public static function getHttpClient()
     {

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -6,14 +6,8 @@ final class Config
 {
     const VERSION = '2.0.0';
 
-    public static $waitTaskRetry = 100;
-
     private static $userAgent;
     private static $customUserAgent = '';
-
-    private static $readTimeout = 5;
-    private static $writeTimeout = 5;
-    private static $connectTimeout = 2;
 
     private static $httpClientConstructor;
 
@@ -33,36 +27,6 @@ final class Config
     public static function addCustomUserAgent($segment, $version)
     {
         static::$customUserAgent .= '; '.trim($segment, ' ').' ('.trim($version, ' ').')';
-    }
-
-    public static function getReadTimeout()
-    {
-        return self::$readTimeout;
-    }
-
-    public static function setReadTimeout($readTimeout)
-    {
-        self::$readTimeout = $readTimeout;
-    }
-
-    public static function getWriteTimeout()
-    {
-        return self::$writeTimeout;
-    }
-
-    public static function setWriteTimeout($writeTimeout)
-    {
-        self::$writeTimeout = $writeTimeout;
-    }
-
-    public static function getConnectTimeout()
-    {
-        return self::$connectTimeout;
-    }
-
-    public static function setConnectTimeout($connectTimeout)
-    {
-        self::$connectTimeout = $connectTimeout;
     }
 
     public static function getHttpClient()

--- a/src/Support/UserAgent.php
+++ b/src/Support/UserAgent.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Support;
+
+final class UserAgent
+{
+    private static $value;
+
+    private static $customSegments = array();
+
+    public static function get()
+    {
+        if (null === self::$value) {
+            self::$value = self::getComputedValue();
+        }
+
+        return self::$value;
+    }
+
+    public static function addCustomUserAgent($segment, $version)
+    {
+        self::$value = null;
+        self::$customSegments[trim($segment, ' ')] = trim($version, ' ');
+    }
+
+    private static function getComputedValue()
+    {
+        $ua = array();
+        $segments = array_merge(self::getDefaultSegments(), self::$customSegments);
+
+        foreach ($segments as $segment => $version) {
+            $ua[] = $segment.' ('.$version.')';
+        }
+
+        return implode('; ', $ua);
+    }
+
+    private static function getDefaultSegments()
+    {
+        $segments = array();
+
+        $segments['Algolia for PHP'] = Config::VERSION;
+        $segments['PHP'] = str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION);
+        if (defined('HHVM_VERSION')) {
+            $segments['HHVM'] = HHVM_VERSION;
+        }
+        if (interface_exists('\GuzzleHttp\ClientInterface')) {
+            $segments['Guzzle'] = \GuzzleHttp\ClientInterface::VERSION;
+        }
+
+        return $segments;
+    }
+}

--- a/tests/API/PublicApiTest.php
+++ b/tests/API/PublicApiTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Tests\API;
 
 use Algolia\AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\Support\ClientConfig;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
@@ -11,7 +12,7 @@ class PublicApiTest extends TestCase
     public function testClient()
     {
         $apiWrapper = $this->createMock('\Algolia\AlgoliaSearch\Internals\ApiWrapper');
-        $client = new Client($apiWrapper);
+        $client = new Client($apiWrapper, ClientConfig::create());
         $definition = $this->getDefinition('client.yaml');
 
         $c = new PublicApiChecker($client, $definition);
@@ -21,7 +22,7 @@ class PublicApiTest extends TestCase
     public function testIndex()
     {
         $apiWrapper = $this->createMock('\Algolia\AlgoliaSearch\Internals\ApiWrapper');
-        $client = new Client($apiWrapper);
+        $client = new Client($apiWrapper, ClientConfig::create());
         $index = $client->initIndex('someindex');
         $definition = $this->getDefinition('index.yaml');
 

--- a/tests/Unit/RequestOptionsFactoryTest.php
+++ b/tests/Unit/RequestOptionsFactoryTest.php
@@ -15,14 +15,17 @@ class RequestOptionsFactoryTest extends TestCase
     public function setUp()
     {
         $this->factory = new RequestOptionsFactory(
-            new ClientConfig('Algolia-Id', 'Algolia-Key'
-        ));
+            new ClientConfig(array(
+                'appId' => 'Algolia-Id',
+                'apiKey' => 'Algolia-Key'
+            ))
+        );
     }
 
     /**
      * @dataProvider provideRequestOptionsData
      */
-    public function testRequestRequestOptions($options, $expectedRequestOptions)
+    public function testRequestOptionsFactory($options, $expectedRequestOptions)
     {
         $actual = $this->factory->create($options);
 

--- a/tests/Unit/RequestOptionsFactoryTest.php
+++ b/tests/Unit/RequestOptionsFactoryTest.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
 use Algolia\AlgoliaSearch\Support\ClientConfig;
-use Algolia\AlgoliaSearch\Support\Config;
+use Algolia\AlgoliaSearch\Support\UserAgent;
 use PHPUnit\Framework\TestCase;
 
 class RequestOptionsFactoryTest extends TestCase
@@ -26,7 +26,7 @@ class RequestOptionsFactoryTest extends TestCase
     {
         $actual = $this->factory->create($options);
 
-        $expectedRequestOptions['headers'] += array('User-Agent' => Config::getUserAgent());
+        $expectedRequestOptions['headers'] += array('User-Agent' => UserAgent::get());
 
         $this->assertEquals($expectedRequestOptions, array(
             'headers' => $actual->getHeaders(),

--- a/tests/Unit/UserAgentTest.php
+++ b/tests/Unit/UserAgentTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Support\Config;
+use Algolia\AlgoliaSearch\Support\UserAgent;
 use PHPUnit\Framework\TestCase;
 
 class UserAgentTest extends TestCase
@@ -11,18 +12,21 @@ class UserAgentTest extends TestCase
 
     public function setUp()
     {
-        $this->default = 'PHP ('.str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION).'); ';
+        $this->default = 'Algolia for PHP ('.Config::VERSION.'); ';
+        $this->default .= 'PHP ('.str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION).')';
         if (defined('HHVM_VERSION')) {
             $this->default .= '; HHVM ('.HHVM_VERSION.')';
         }
-        $this->default .= 'Algolia for PHP ('.Config::VERSION.')';
+        if (interface_exists('\GuzzleHttp\ClientInterface')) {
+            $this->default .= '; Guzzle ('.\GuzzleHttp\ClientInterface::VERSION.')';
+        }
     }
 
     public function testDefaultUserAgent()
     {
-        $this->assertRegExp('/^PHP \(\d+\.\d+\.\d+\); Algolia for PHP \(\d+\.\d+\.\d+\)$/', Config::getUserAgent());
+        $this->assertRegExp('/^Algolia for PHP \(\d+\.\d+\.\d+\); PHP \(\d+\.\d+\.\d+\).*$/', UserAgent::get());
 
-        $this->assertEquals($this->default, Config::getUserAgent());
+        $this->assertEquals($this->default, UserAgent::get());
     }
 
     public function testWithCustomUserAgent()
@@ -31,22 +35,22 @@ class UserAgentTest extends TestCase
         $version1 = '1.23.4';
         $custom1 = '; '.$segment1.' ('.$version1.')';
         // Add extra spaces to ensure they're trimmed
-        Config::addCustomUserAgent(' '.$segment1.' ', ' '.$version1.' ');
+        UserAgent::addCustomUserAgent(' '.$segment1.' ', ' '.$version1.' ');
 
         $this->assertEquals(
             $this->default.$custom1,
-            Config::getUserAgent()
+            UserAgent::get()
         );
 
         $segment2 = 'Framework Xtra lib';
         $version2 = '1.0.4';
         $custom2 = '; '.$segment2.' ('.$version2.')';
         // Add extra spaces to ensure they're trimmed
-        Config::addCustomUserAgent(' '.$segment2.' ', ' '.$version2.' ');
+        UserAgent::addCustomUserAgent(' '.$segment2.' ', ' '.$version2.' ');
 
         $this->assertEquals(
             $this->default.$custom1.$custom2,
-            Config::getUserAgent()
+            UserAgent::get()
         );
     }
 }


### PR DESCRIPTION
In the current version, we have `Config` for global (static) configuration and `ClientConfig` for the configuration of a client intance. As discussed this morning, we'd like to have only one (instance) config.

I have refactored the UserAgent, the timeouts and waitBeforeRetry config. I believe it makes much more sense, it was a good move.

Although, I'm stuck with the HttpClient builder method and the `VERSION` number. Where do you thing these should move?