### PR TITLE
Refacto/remove default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 * Introduce ClientConfiguration
 * Introduce Client singleton with `Client::get()`
 
+#### 2.0 Alpha 3
+
+* Remove all default values for optional parameters
+    To enforce that, $default parameters is removed from APIWrapper methods.
+    It's still available in the RequestOptionsFactory
+
 
 ### UNRELEASED
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,10 +205,7 @@ class Client implements ClientInterface
 
     public function listUserIds($requestOptions = array())
     {
-        return $this->api->read('GET', api_path('/1/clusters/mapping'), $requestOptions, array(
-            'page' => 0,
-            'hitsPerPage' => 20,
-        ));
+        return $this->api->read('GET', api_path('/1/clusters/mapping'), $requestOptions);
     }
 
     public function getUserId($userId, $requestOptions = array())
@@ -257,11 +254,7 @@ class Client implements ClientInterface
 
     public function getLogs($requestOptions = array())
     {
-        return $this->api->read('GET', api_path('/1/logs'), $requestOptions, array(
-            'offset' => 0,
-            'length' => 10,
-            'type' => 'all',
-        ));
+        return $this->api->read('GET', api_path('/1/logs'), $requestOptions);
     }
 
     public function getTask($indexName, $taskId, $requestOptions = array())

--- a/src/Index.php
+++ b/src/Index.php
@@ -60,13 +60,16 @@ class Index implements IndexInterface
 
     public function getSettings($requestOptions = array())
     {
+        if (is_array($requestOptions)) {
+            $requestOptions['getVersion'] = 2;
+        } elseif ($requestOptions instanceof RequestOptions) {
+            $requestOptions->addQueryParameter('getVersion', 2);
+        }
+
         return $this->api->read(
             'GET',
             api_path('/1/indexes/%s/settings', $this->indexName),
-            $requestOptions,
-            array(
-                'getVersion' => 2,
-            )
+            $requestOptions
         );
     }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -76,10 +76,7 @@ class Index implements IndexInterface
             'PUT',
             api_path('/1/indexes/%s/settings', $this->indexName),
             $settings,
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -262,10 +259,7 @@ class Index implements IndexInterface
             'POST',
             api_path('/1/indexes/%s/synonyms/batch', $this->indexName),
             $synonyms,
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -286,10 +280,7 @@ class Index implements IndexInterface
             'DELETE',
             api_path('/1/indexes/%s/synonyms/%s', $this->indexName, $objectId),
             array(),
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -299,10 +290,7 @@ class Index implements IndexInterface
             'POST',
             api_path('/1/indexes/%s/synonyms/clear', $this->indexName),
             array(),
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -348,10 +336,7 @@ class Index implements IndexInterface
             'POST',
             api_path('/1/indexes/%s/rules/batch', $this->indexName),
             $rules,
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -372,10 +357,7 @@ class Index implements IndexInterface
             'DELETE',
             api_path('/1/indexes/%s/rules/%s', $this->indexName, $objectId),
             array(),
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 
@@ -385,10 +367,7 @@ class Index implements IndexInterface
             'POST',
             api_path('/1/indexes/%s/rules/clear', $this->indexName),
             array(),
-            $requestOptions,
-            array(
-                'forwardToReplicas' => true,
-            )
+            $requestOptions
         );
     }
 

--- a/src/Internals/ApiWrapper.php
+++ b/src/Internals/ApiWrapper.php
@@ -38,12 +38,12 @@ class ApiWrapper
         $this->requestOptionsFactory = $RqstOptsFactory ? $RqstOptsFactory : new RequestOptionsFactory($config);
     }
 
-    public function read($method, $path, $requestOptions = array(), $defaults = array())
+    public function read($method, $path, $requestOptions = array())
     {
         if ('GET' == strtoupper($method)) {
-            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions, $defaults);
+            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions);
         } else {
-            $requestOptions = $this->requestOptionsFactory->create($requestOptions, $defaults);
+            $requestOptions = $this->requestOptionsFactory->create($requestOptions);
         }
 
         return $this->request(
@@ -55,13 +55,13 @@ class ApiWrapper
         );
     }
 
-    public function write($method, $path, $data = array(), $requestOptions = array(), $defaults = array())
+    public function write($method, $path, $data = array(), $requestOptions = array())
     {
         if ('DELETE' == strtoupper($method)) {
-            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions, $defaults);
+            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions);
             $data = array();
         } else {
-            $requestOptions = $this->requestOptionsFactory->create($requestOptions, $defaults);
+            $requestOptions = $this->requestOptionsFactory->create($requestOptions);
         }
 
         return $this->request(

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -20,6 +20,7 @@ class RequestOptionsFactory
 
     private $validHeaders = array(
         'Content-type',
+        'User-Agent',
     );
 
     public function __construct(ClientConfig $config)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | YES  
| Need Doc update   | yes


## Describe your change

I have removed the default values for optional parameters. After discussing it yesterday, we decided thst we should keep the engine values if the user doesn't specify them.

⚠️ This means that `forwardToRepliccas` is default to FALSE (like in v1 and all other clients. The v2 originally defaulted it to TRUE, this is entirely rolled back.

There is one default value left, it's the `getVersion=2` for `Index::getSettings`. I believe this one still makes a lot of sense. The engine introduce the version for settings to keep BC but the version2 should be used as much as possible.