### PR TITLE
Fixes PSR-1 violation on helpers methods names

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -87,7 +87,7 @@ class Client implements ClientInterface
 
     public function multipleBatchObjects($operations, $requestOptions = array())
     {
-        Helpers::ensure_objectID($operations);
+        Helpers::ensureObjectID($operations);
 
         if (is_array($requestOptions)) {
             $requestOptions['requests'] = $operations;
@@ -192,7 +192,7 @@ class Client implements ClientInterface
     // BC Break: signature was changed
     public static function generateSecuredApiKey($parentApiKey, $restrictions)
     {
-        $urlEncodedRestrictions = Helpers::build_query($restrictions);
+        $urlEncodedRestrictions = Helpers::buildQuery($restrictions);
 
         $content = hash_hmac('sha256', $urlEncodedRestrictions, $parentApiKey).$urlEncodedRestrictions;
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -138,9 +138,9 @@ class Index implements IndexInterface
 
     public function saveObjects($objects, $requestOptions = array())
     {
-        Helpers::ensure_objectID($objects, 'All objects must have an unique objectID (like a primary key) to be valid.');
+        Helpers::ensureObjectID($objects, 'All objects must have an unique objectID (like a primary key) to be valid.');
 
-        return $this->batch(Helpers::build_batch($objects, 'addObject'), $requestOptions);
+        return $this->batch(Helpers::buildBatch($objects, 'addObject'), $requestOptions);
     }
 
     public function partialUpdateObject($object, $requestOptions = array())
@@ -150,7 +150,7 @@ class Index implements IndexInterface
 
     public function partialUpdateObjects($objects, $requestOptions = array())
     {
-        return $this->batch(Helpers::build_batch($objects, 'partialUpdateObjectNoCreate'), $requestOptions);
+        return $this->batch(Helpers::buildBatch($objects, 'partialUpdateObjectNoCreate'), $requestOptions);
     }
 
     public function partialUpdateOrCreateObject($object, $requestOptions = array())
@@ -160,7 +160,7 @@ class Index implements IndexInterface
 
     public function partialUpdateOrCreateObjects($objects, $requestOptions = array())
     {
-        return $this->batch(Helpers::build_batch($objects, 'partialUpdateObject'), $requestOptions);
+        return $this->batch(Helpers::buildBatch($objects, 'partialUpdateObject'), $requestOptions);
     }
 
     public function freshObjects($objects, $requestOptions = array())
@@ -203,7 +203,7 @@ class Index implements IndexInterface
             return array('objectID' => $id);
         }, $objectIds);
 
-        return $this->batch(Helpers::build_batch($objects, 'deleteObject'), $requestOptions);
+        return $this->batch(Helpers::buildBatch($objects, 'deleteObject'), $requestOptions);
     }
 
     public function deleteBy(array $args, $requestOptions = array())
@@ -211,7 +211,7 @@ class Index implements IndexInterface
         return $this->api->write(
             'POST',
             api_path('/1/indexes/%s/deleteByQuery', $this->indexName),
-            array('params' => Helpers::build_query($args)),
+            array('params' => Helpers::buildQuery($args)),
             $requestOptions
         );
     }
@@ -262,7 +262,7 @@ class Index implements IndexInterface
 
     public function saveSynonyms($synonyms, $requestOptions = array())
     {
-        Helpers::ensure_objectID($synonyms, 'All synonyms must have an unique objectID to be valid');
+        Helpers::ensureObjectID($synonyms, 'All synonyms must have an unique objectID to be valid');
 
         return $this->api->write(
             'POST',
@@ -339,7 +339,7 @@ class Index implements IndexInterface
 
     public function saveRules($rules, $requestOptions = array())
     {
-        Helpers::ensure_objectID($rules, 'All rules must have an unique objectID to be valid');
+        Helpers::ensureObjectID($rules, 'All rules must have an unique objectID to be valid');
 
         return $this->api->write(
             'POST',

--- a/src/Iterators/ObjectIterator.php
+++ b/src/Iterators/ObjectIterator.php
@@ -33,7 +33,7 @@ class ObjectIterator extends AbstractAlgoliaIterator
 
         $this->response = $this->api->read(
             empty($reqOpts) ? 'GET' : 'POST',
-            Helpers::api_path('/1/indexes/%s/browse', $this->indexName),
+            Helpers::apiPath('/1/indexes/%s/browse', $this->indexName),
             array_merge(
                 $this->requestOptions,
                 $cursor

--- a/src/Iterators/RuleIterator.php
+++ b/src/Iterators/RuleIterator.php
@@ -17,7 +17,7 @@ class RuleIterator extends AbstractAlgoliaIterator
     {
         $this->response = $this->api->read(
             'POST',
-            Helpers::api_path('/1/indexes/%s/rules/search', $this->indexName),
+            Helpers::apiPath('/1/indexes/%s/rules/search', $this->indexName),
             array_merge(
                 $this->requestOptions,
                 array('page' => $this->getCurrentPage())

--- a/src/Iterators/SynonymIterator.php
+++ b/src/Iterators/SynonymIterator.php
@@ -17,7 +17,7 @@ class SynonymIterator extends AbstractAlgoliaIterator
     {
         $this->response = $this->api->read(
             'POST',
-            Helpers::api_path('/1/indexes/%s/synonyms/search', $this->indexName),
+            Helpers::apiPath('/1/indexes/%s/synonyms/search', $this->indexName),
             array_merge(
                 $this->requestOptions,
                 array('page' => $this->getCurrentPage())

--- a/src/RequestOptions/RequestOptions.php
+++ b/src/RequestOptions/RequestOptions.php
@@ -82,7 +82,7 @@ class RequestOptions
 
     public function getBuiltQueryParameters()
     {
-        return Helpers::build_query($this->query);
+        return Helpers::buildQuery($this->query);
     }
 
     public function addQueryParameter($name, $value)

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -23,7 +23,7 @@ class Helpers
      *
      * @return mixed
      */
-    public static function api_path($pathFormat, $args = null, $_ = null)
+    public static function apiPath($pathFormat, $args = null, $_ = null)
     {
         $arguments = array_slice(func_get_args(), 1);
         foreach ($arguments as &$arg) {
@@ -36,7 +36,7 @@ class Helpers
 
     /**
      * When building a query string, array values must be json_encoded.
-     * This function can be used to turn any array into a Algilia-valid query string.
+     * This function can be used to turn any array into a Algolia-valid query string.
      *
      * Do not use a typical implementation where ['key' => ['one', 'two']] is
      * turned into key[1]=one&key[2]=two. Algolia will not understand key[x].
@@ -46,7 +46,7 @@ class Helpers
      *
      * @return string The urlencoded query string to send to Algolia
      */
-    public static function build_query(array $args)
+    public static function buildQuery(array $args)
     {
         if (!$args) {
             return '';
@@ -65,7 +65,7 @@ class Helpers
         return http_build_query($args);
     }
 
-    public static function build_batch($items, $action)
+    public static function buildBatch($items, $action)
     {
         return array_map(function ($item) use ($action) {
             return array(
@@ -75,7 +75,7 @@ class Helpers
         }, $items);
     }
 
-    public static function ensure_objectID($objects, $message = 'ObjectID is required to add a record, a synonym or a query rule.')
+    public static function ensureObjectID($objects, $message = 'ObjectID is required to add a record, a synonym or a query rule.')
     {
         // In case a single objects is passed
         if (isset($objects['objectID'])) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,5 +4,5 @@ namespace Algolia\AlgoliaSearch;
 
 function api_path($pathFormat, $args = null, $_ = null)
 {
-    return call_user_func_array(array('\Algolia\AlgoliaSearch\Support\Helpers', 'api_path'), func_get_args());
+    return call_user_func_array(array('\Algolia\AlgoliaSearch\Support\Helpers', 'apiPath'), func_get_args());
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -18,10 +18,10 @@ class HelpersTest extends TestCase
     public function dataTestApiPathHelper()
     {
         return array(array(
-            Helpers::api_path('/1/indexes/%s/cool/%s', 'index name', 'b&w'),
+            Helpers::apiPath('/1/indexes/%s/cool/%s', 'index name', 'b&w'),
             '/1/indexes/index+name/cool/b%26w',
         ), array(
-            Helpers::api_path('/1/indexes/%s/cool/%s', 'index name', urlencode('b&w')),
+            Helpers::apiPath('/1/indexes/%s/cool/%s', 'index name', urlencode('b&w')),
             '/1/indexes/index+name/cool/b%26w',
         ));
     }
@@ -33,7 +33,7 @@ class HelpersTest extends TestCase
     {
         $this->assertEquals(
             $expected,
-            Helpers::build_query($queryParams)
+            Helpers::buildQuery($queryParams)
         );
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

This Pull Request addresses a violation of PSR-1: Method names should be declared in camelCase.