### PR TITLE
[RFC] Introduce setSettingsWithReplicas() method

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -81,11 +81,17 @@ class Index implements IndexInterface
 
     public function setSettings($settings, $requestOptions = array())
     {
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'PUT',
             api_path('/1/indexes/%s/settings', $this->indexName),
             $settings,
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
@@ -264,11 +270,17 @@ class Index implements IndexInterface
     {
         Helpers::ensureObjectID($synonyms, 'All synonyms must have an unique objectID to be valid');
 
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'POST',
             api_path('/1/indexes/%s/synonyms/batch', $this->indexName),
             $synonyms,
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
@@ -285,21 +297,33 @@ class Index implements IndexInterface
 
     public function deleteSynonym($objectId, $requestOptions = array())
     {
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'DELETE',
             api_path('/1/indexes/%s/synonyms/%s', $this->indexName, $objectId),
             array(),
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
     public function clearSynonyms($requestOptions = array())
     {
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'POST',
             api_path('/1/indexes/%s/synonyms/clear', $this->indexName),
             array(),
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
@@ -341,11 +365,17 @@ class Index implements IndexInterface
     {
         Helpers::ensureObjectID($rules, 'All rules must have an unique objectID to be valid');
 
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'POST',
             api_path('/1/indexes/%s/rules/batch', $this->indexName),
             $rules,
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
@@ -362,21 +392,33 @@ class Index implements IndexInterface
 
     public function deleteRule($objectId, $requestOptions = array())
     {
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'DELETE',
             api_path('/1/indexes/%s/rules/%s', $this->indexName, $objectId),
             array(),
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 
     public function clearRules($requestOptions = array())
     {
+        $default = array();
+        if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
+            $default['forwardToReplicas'] = $fwd;
+        }
+
         return $this->api->write(
             'POST',
             api_path('/1/indexes/%s/rules/clear', $this->indexName),
             array(),
-            $requestOptions
+            $requestOptions,
+            $default
         );
     }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -89,6 +89,22 @@ class Index implements IndexInterface
         );
     }
 
+    public function setSettingsWithReplicas($settings, $requestOptions = array())
+    {
+        if (is_array($requestOptions)) {
+            $requestOptions['forwardToReplicas'] = true;
+        } elseif ($requestOptions instanceof RequestOptions) {
+            $requestOptions->addQueryParameter('forwardToReplicas', true);
+        }
+
+        return $this->api->write(
+            'PUT',
+            api_path('/1/indexes/%s/settings', $this->indexName),
+            $settings,
+            $requestOptions
+        );
+    }
+
     public function getObject($objectId, $requestOptions = array())
     {
         return $this->api->read(

--- a/src/Index.php
+++ b/src/Index.php
@@ -89,22 +89,6 @@ class Index implements IndexInterface
         );
     }
 
-    public function setSettingsWithReplicas($settings, $requestOptions = array())
-    {
-        if (is_array($requestOptions)) {
-            $requestOptions['forwardToReplicas'] = true;
-        } elseif ($requestOptions instanceof RequestOptions) {
-            $requestOptions->addQueryParameter('forwardToReplicas', true);
-        }
-
-        return $this->api->write(
-            'PUT',
-            api_path('/1/indexes/%s/settings', $this->indexName),
-            $settings,
-            $requestOptions
-        );
-    }
-
     public function getObject($objectId, $requestOptions = array())
     {
         return $this->api->read(

--- a/src/Interfaces/ClientConfigInterface.php
+++ b/src/Interfaces/ClientConfigInterface.php
@@ -26,6 +26,19 @@ interface ClientConfigInterface extends LoggerAwareInterface
 
     public function getWaitTaskTimeBeforeRetry();
 
+    public function getDefaultForwardToReplicas();
+
+    /**
+     * Every methods accepting `forwardToReplicas` parameters will use
+     * this value by default. If you don't set it, the engine default
+     * value will be used.
+     *
+     * @param boolean $default
+     * @return $this
+     */
+    public function setDefaultForwardToReplicas($default);
+
+
     /**
      * Gets the logger instance of the object.
      *

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -40,12 +40,12 @@ class ApiWrapper
         $this->requestOptionsFactory = $RqstOptsFactory ?: new RequestOptionsFactory($config);
     }
 
-    public function read($method, $path, $requestOptions = array())
+    public function read($method, $path, $requestOptions = array(), $defaultRequestOptions = array())
     {
         if ('GET' == strtoupper($method)) {
-            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions);
+            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions, $defaultRequestOptions);
         } else {
-            $requestOptions = $this->requestOptionsFactory->create($requestOptions);
+            $requestOptions = $this->requestOptionsFactory->create($requestOptions, $defaultRequestOptions);
         }
 
         return $this->request(
@@ -57,13 +57,13 @@ class ApiWrapper
         );
     }
 
-    public function write($method, $path, $data = array(), $requestOptions = array())
+    public function write($method, $path, $data = array(), $requestOptions = array(), $defaultRequestOptions = array())
     {
         if ('DELETE' == strtoupper($method)) {
-            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions);
+            $requestOptions = $this->requestOptionsFactory->createBodyLess($requestOptions, $defaultRequestOptions);
             $data = array();
         } else {
-            $requestOptions = $this->requestOptionsFactory->create($requestOptions);
+            $requestOptions = $this->requestOptionsFactory->create($requestOptions, $defaultRequestOptions);
         }
 
         return $this->request(

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -68,6 +68,7 @@ class ClientConfig implements ClientConfigInterface
             'connectTimeout' => $this->defaultConnectTimeout,
             'waitTaskTimeBeforeRetry' => $this->defaultWaitTaskTimeBeforeRetry,
             'waitTaskMaxRetry' => $this->defaultWaitTaskMaxRetry,
+            'defaultForwardToReplicas' => null,
         );
     }
 
@@ -163,6 +164,22 @@ class ClientConfig implements ClientConfigInterface
     public function setWaitTaskTimeBeforeRetry($time)
     {
         $this->config['waitTaskTimeBeforeRetry'] = $time;
+
+        return $this;
+    }
+
+    public function getDefaultForwardToReplicas()
+    {
+        return $this->config['defaultForwardToReplicas'];
+    }
+
+    public function setDefaultForwardToReplicas($default)
+    {
+        if (! is_bool($default)) {
+            throw new \InvalidArgumentException('Default configuration for ForwardToReplicas must be a boolean');
+        }
+
+        $this->config['defaultForwardToReplicas'] = $default;
 
         return $this;
     }

--- a/tests/Endpoint/ForwardToReplicasDefaultTest.php
+++ b/tests/Endpoint/ForwardToReplicasDefaultTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Endpoint;
+
+use Algolia\AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\Support\ClientConfig;
+
+class ForwardToReplicasDefaultTest extends RequestTestCase
+{
+    public function testIndexDoesNotSetForwardToReplicasByDefault()
+    {
+        /** @var \Algolia\AlgoliaSearch\Index $index */
+        $index = Client::get()->initIndex('test');
+
+        $methods = array(
+            'setSettings' => array(),
+            'saveSynonym' => array('objectID' => 'xx'),
+            'saveRule' => array('objectID' => 'xx'),
+            'saveSynonyms' => array(array('objectID' => 'xx')),
+            'saveRules' => array(array('objectID' => 'xx')),
+            'freshSynonyms' => array(array('objectID' => 'xx')),
+            'freshRules' => array(array('objectID' => 'xx')),
+            'deleteSynonym' => 'id',
+            'deleteRule' => 'id',
+            'clearSynonyms' => array(),
+            'clearRules' => array(),
+        );
+
+        foreach ($methods as $methodName => $arg1) {
+            list($request, $timeout, $connectTimeout) = $index->{$methodName}($arg1);
+
+            $this->assertQueryParametersNotHasKey('forwardToReplicas', $request);
+        }
+    }
+
+    /**
+     * @dataProvider provideConfigDefaultValue
+     */
+    public function testIndexUseConfigDefaultForwardToReplicas($defaultValue)
+    {
+        /** @var \Algolia\AlgoliaSearch\Index $index */
+        $index = Client::createWithConfig(new ClientConfig(array(
+            'defaultForwardToReplicas' => $defaultValue
+        )))->initIndex('test');
+
+        $methods = array(
+            'setSettings' => array(),
+            'saveSynonym' => array('objectID' => 'xx'),
+            'saveRule' => array('objectID' => 'xx'),
+            'saveSynonyms' => array(array('objectID' => 'xx')),
+            'saveRules' => array(array('objectID' => 'xx')),
+            'freshSynonyms' => array(array('objectID' => 'xx')),
+            'freshRules' => array(array('objectID' => 'xx')),
+            'deleteSynonym' => 'id',
+            'deleteRule' => 'id',
+            'clearSynonyms' => array(),
+            'clearRules' => array(),
+        );
+
+        foreach ($methods as $methodName => $arg1) {
+            list($request, $timeout, $connectTimeout) = $index->{$methodName}($arg1);
+
+            $this->assertQueryParametersSubset(
+                array('forwardToReplicas' => $defaultValue ? 'true':'false'),
+                $request
+            );
+        }
+    }
+
+    public function provideConfigDefaultValue()
+    {
+        return array(
+            array(true), array(false),
+        );
+    }
+}

--- a/tests/Endpoint/RequestTestCase.php
+++ b/tests/Endpoint/RequestTestCase.php
@@ -36,4 +36,24 @@ abstract class RequestTestCase extends TestCase
         $body = json_decode((string) $request->getBody(), true);
         $this->assertArraySubset($subset, $body);
     }
+
+    protected function assertQueryParametersSubset(array $subset, RequestInterface $request)
+    {
+        $params = $this->requestQueryParametersToArray($request);
+        $this->assertArraySubset($subset, $params);
+    }
+
+    protected function assertQueryParametersNotHasKey($key, RequestInterface $request)
+    {
+        $params = $this->requestQueryParametersToArray($request);
+        $this->assertArrayNotHasKey($key, $params);
+    }
+
+    private function requestQueryParametersToArray(RequestInterface $request)
+    {
+        $array = array();
+        parse_str($request->getUri()->getQuery(), $array);
+
+        return $array;
+    }
 }

--- a/tests/Integration/AlgoliaIntegrationTestCase.php
+++ b/tests/Integration/AlgoliaIntegrationTestCase.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Client;
+use Algolia\AlgoliaSearch\Support\ClientConfig;
 use Algolia\AlgoliaSearch\Tests\SyncClient;
 use PHPUnit\Framework\TestCase as PHPUitTestCase;
 
@@ -45,12 +46,12 @@ abstract class AlgoliaIntegrationTestCase extends PHPUitTestCase
     protected static function newClient($config = array())
     {
         $config += array(
-            'app-id' => getenv('ALGOLIA_APP_ID'),
-            'key' => getenv('ALGOLIA_API_KEY'),
+            'appId' => getenv('ALGOLIA_APP_ID'),
+            'apiKey' => getenv('ALGOLIA_API_KEY'),
         );
 
         return new SyncClient(
-            Client::create($config['app-id'], $config['key'])
+            Client::createWithConfig(new ClientConfig($config))
         );
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

# Update

Instead of adding so many method, I introduce a config option for default to `forwardToReplica = true` based on @nunomaduro's feedback.

This will be used this way:

```php
$client = Client::createWithConfig(['defaultForwardToReplicas' => true]);

$client->initIndex('name')->setSettings($settings); // Will be forwarded to replicas
$client->initIndex('name')->setSettings($settings, ['fowardToReplicas' => false); // Will *NOT* be forwarded 

```

## Describe your change

~I added a method named `setSettingsWithReplicas` with basically call `setSettings` with the `forwardToReplicas` set to true (default is false).~

```php
$index->setSettingsWithReplicas($settings);
// Instead of 
$index->setSettings($settings, ['forwardToReplicas' => true]);
```

### Why

We know that most of the time, developer need to forward the settings, synonyms and rules to replica indexes.

When we started this v2, we decided to turn forwardToReplicas to `true`by default. We recently revised that and decided that we should stick to the REST API defaults. Which I think was the best decision.

The goal of this method is to make things explicit. Users will understand better that calling `setSettings` will not set the settings to replica indexes.

I believe the maintenance cost is very limited, the method only proxy another method, once it's written, everything should be fine.

### Tests

To test all the proxy methods, I'll add something to test that a proxy method call the correct mehtod with the correct arguments. See #434 


## Need feedback

I'm not sure this PR should be merge, I'd like to get your opinion on it. 🙏 

If we decide to move forward with this, we should also add:

```
saveSynonymWithReplicas()
saveSynonymsWithReplicas()
freshSynonymWithReplicas()
freshSynonymsWithReplicas()
clearSynonymWithReplicas()
clearSynonymsWithReplicas()
deleteSynonymWithReplicas()
deleteSynonymsWithReplicas()

saveRuleWithReplicas()
saveRulesWithReplicas()
freshRuleWithReplicas()
freshRulesWithReplicas()
clearRuleWithReplicas()
clearRulesWithReplicas()
deleteRuleWithReplicas()
deleteRulesWithReplicas()
```