### PR TITLE
Introduce Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 /vendor/
 .php_cs.cache
+/tests/cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Fix Travis
 * Introduce ClientConfiguration
 * Introduce Client singleton with `Client::get()`
+* Remove Canary
+* Add PSR-16 compliant Cache
 
 #### 2.0 Alpha 3
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^6.5",

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -2,7 +2,51 @@
 
 namespace Algolia\AlgoliaSearch;
 
+use Algolia\AlgoliaSearch\Cache\NullCache;
+use Psr\SimpleCache\CacheInterface;
+
 class Algolia
 {
     const VERSION = '2.0.0';
+
+    /**
+     * Holds an instance of the simple cache repository (PSR-16).
+     *
+     * @var \Psr\SimpleCache\CacheInterface|null
+     */
+    private static $cache;
+
+    public static function isCacheEnabled()
+    {
+        if (null === self::$cache) {
+            return false;
+        }
+
+        return (! self::getCache() instanceof NullCache);
+    }
+
+    /**
+     * Gets the cache instance of the object.
+     *
+     * @return \Psr\SimpleCache\CacheInterface
+     */
+    public static function getCache()
+    {
+        if (! self::$cache) {
+            self::setCache(new NullCache());
+        }
+
+        return self::$cache;
+    }
+
+    /**
+     * Sets the cache instance of the object.
+     *
+     * @param \Psr\SimpleCache\CacheInterface $cache
+     * @return void
+     */
+    public static function setCache(CacheInterface $cache)
+    {
+        self::$cache = $cache;
+    }
 }

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch;
 
-use Algolia\AlgoliaSearch\Cache\NullCache;
+use Algolia\AlgoliaSearch\Cache\NullCacheDriver;
 use Psr\SimpleCache\CacheInterface;
 
 class Algolia
@@ -22,7 +22,7 @@ class Algolia
             return false;
         }
 
-        return (! self::getCache() instanceof NullCache);
+        return (! self::getCache() instanceof NullCacheDriver);
     }
 
     /**
@@ -33,7 +33,7 @@ class Algolia
     public static function getCache()
     {
         if (! self::$cache) {
-            self::setCache(new NullCache());
+            self::setCache(new NullCacheDriver());
         }
 
         return self::$cache;

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -37,9 +37,18 @@ final class Analytics
 
     public static function createWithConfig(ClientConfigInterface $config)
     {
+        $config = clone $config;
+
+        if ($hosts = $config->getHosts()) {
+            $clusterHosts = ClusterHosts::create($hosts);
+        } else {
+            $clusterHosts = ClusterHosts::createForAnalytics();
+        }
+
         $apiWrapper = new ApiWrapper(
             HttpClientFactory::get($config),
-            $config
+            $config,
+            $clusterHosts
         );
 
         return new static($apiWrapper, $config);

--- a/src/Cache/FileCacheDriver.php
+++ b/src/Cache/FileCacheDriver.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+class FileCacheDriver implements CacheInterface
+{
+    const PREFIX = 'algolia-client-';
+
+    private $directory;
+
+    public function __construct($directory)
+    {
+        $this->directory = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($key, $default = null)
+    {
+        if (! $this->has($key)) {
+            return $default;
+        }
+
+        return file_get_contents($this->getFilenameFromKey($key));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return file_put_contents($this->getFilenameFromKey($key), $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delete($key)
+    {
+        return @unlink($this->getFilenameFromKey($key));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function clear()
+    {
+        $result = true;
+        foreach (glob($this->directory.self::PREFIX.'*') as $file) {
+            $result &= @unlink($file);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $result = array();
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $result = true;
+        foreach ($values as $key => $value) {
+            $result &= $this->set($key, $value, $ttl);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deleteMultiple($keys)
+    {
+        $result = true;
+        foreach ($keys as $key ) {
+            $result &= $this->delete($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function has($key)
+    {
+        return file_exists($this->getFilenameFromKey($key));
+    }
+
+    /**
+     * @param $key
+     * @return string
+     */
+    private function getFilenameFromKey($key)
+    {
+        $name = $this->directory . self::PREFIX .$key;
+
+        return str_replace('\\', '-', $name);
+    }
+}

--- a/src/Cache/FileCacheDriver.php
+++ b/src/Cache/FileCacheDriver.php
@@ -104,7 +104,7 @@ class FileCacheDriver implements CacheInterface
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @return string
      */
     private function getFilenameFromKey($key)

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+class NullCache implements CacheInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key, $default = null)
+    {
+        return $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $return = array();
+
+        foreach ($keys as $key) {
+            $return[$key] = $default;
+        }
+
+        return $return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMultiple($keys)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($key)
+    {
+        return false;
+    }
+}

--- a/src/Cache/NullCacheDriver.php
+++ b/src/Cache/NullCacheDriver.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class NullCache implements CacheInterface
+class NullCacheDriver implements CacheInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Interfaces/ClientConfigInterface.php
+++ b/src/Interfaces/ClientConfigInterface.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Interfaces;
 
 use Psr\Log\LoggerAwareInterface;
+use Psr\SimpleCache\CacheInterface;
 
 interface ClientConfigInterface extends LoggerAwareInterface
 {

--- a/src/RetryStrategy/ClusterHosts.php
+++ b/src/RetryStrategy/ClusterHosts.php
@@ -24,17 +24,16 @@ class ClusterHosts
 
     public static function create($read, $write = null)
     {
-        // TODO: To be fixed
         if (null === $write) {
             $write = $read;
         }
 
         if (is_string($read)) {
-            $read = array($read);
+            $read = array($read => 0);
         }
 
         if (is_string($write)) {
-            $write = array($write);
+            $write = array($write => 0);
         }
 
         return new static(HostCollection::create($read), HostCollection::create($write));
@@ -71,6 +70,19 @@ class ClusterHosts
     public static function createForAnalytics()
     {
         return static::create('analytics.algolia.com');
+    }
+
+    public static function createFromCache($cacheKey)
+    {
+        if (! Algolia::isCacheEnabled()) {
+            return false;
+        }
+
+        if (! Algolia::getCache()->has($cacheKey)) {
+            return false;
+        }
+
+        return @unserialize(Algolia::getCache()->get($cacheKey));
     }
 
     public function read()
@@ -112,8 +124,8 @@ class ClusterHosts
     /**
      * Sets the cache key to save the state of the ClusterHosts
      *
-     * @param $cacheKey
-     * @return string $cacheKey
+     * @param string $cacheKey
+     * @return $this
      */
     public function setCacheKey($cacheKey)
     {

--- a/src/RetryStrategy/Host.php
+++ b/src/RetryStrategy/Host.php
@@ -53,7 +53,7 @@ class Host
 
     private function resetIfExpired()
     {
-        $expired = $this->lastCheck + self::TTL > time();
+        $expired = $this->lastCheck + self::TTL < time();
 
         if ($expired) {
             $this->reset();

--- a/src/RetryStrategy/HostCollection.php
+++ b/src/RetryStrategy/HostCollection.php
@@ -25,9 +25,12 @@ class HostCollection
 
     public function get()
     {
-        return array_filter($this->hosts, function (Host $host) {
+        // We pass the result through array_values because sometimes
+        // we need to make sure you can access the first element
+        // via $result[0]
+        return array_values(array_filter($this->hosts, function (Host $host) {
             return $host->isUp();
-        });
+        }));
     }
 
     public function getUrls()
@@ -39,9 +42,11 @@ class HostCollection
 
     public function markAsDown($hostKey)
     {
-        if (isset($this->hosts[$hostKey])) {
-            $this->hosts[$hostKey]->markAsDown();
-        }
+        array_map(function (Host $host) use ($hostKey) {
+            if ($host->getUrl() === $hostKey) {
+                $host->markAsDown();
+            }
+        }, $this->hosts);
     }
 
     public function shuffle()

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -32,13 +32,16 @@ class ClientConfig implements ClientConfigInterface
      */
     private static $defaultLogger;
 
+    /**
+     * Holds an instance of the default cache repository.
+     *
+     * @var \Psr\SimpleCache\CacheInterface|null
+     */
+    private static $defaultCache;
+
     public function __construct(array $config = array())
     {
         $config += $this->getDefaultConfig();
-
-        if (null === $config['hosts']) {
-            $config['hosts'] = ClusterHosts::createFromAppId($config['appId']);
-        }
 
         $this->config = $config;
     }

--- a/src/Support/ClientConfig.php
+++ b/src/Support/ClientConfig.php
@@ -32,13 +32,6 @@ class ClientConfig implements ClientConfigInterface
      */
     private static $defaultLogger;
 
-    /**
-     * Holds an instance of the default cache repository.
-     *
-     * @var \Psr\SimpleCache\CacheInterface|null
-     */
-    private static $defaultCache;
-
     public function __construct(array $config = array())
     {
         $config += $this->getDefaultConfig();
@@ -104,7 +97,7 @@ class ClientConfig implements ClientConfigInterface
         return $this->config['hosts'];
     }
 
-    public function setHosts(ClusterHosts $hosts)
+    public function setHosts($hosts)
     {
         $this->config['hosts'] = $hosts;
 

--- a/tests/Integration/FileCacheDriverTest.php
+++ b/tests/Integration/FileCacheDriverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Integration;
+
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Cache\FileCacheDriver;
+use Algolia\AlgoliaSearch\Cache\NullCacheDriver;
+use Algolia\AlgoliaSearch\Client;
+
+class FileCacheDriverTest extends AlgoliaIntegrationTestCase
+{
+    private static $cacheDir;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUp();
+
+        self::$cacheDir = dirname(__DIR__).'/cache/';
+        if (!file_exists(self::$cacheDir)) {
+            mkdir(self::$cacheDir);
+        }
+
+        Algolia::setCache(new FileCacheDriver(self::$cacheDir));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        Algolia::setCache(new NullCacheDriver);
+    }
+
+    public function testClusterHostsIsCached()
+    {
+        $client = Client::create();
+        $clusterHosts = $this->getClusterHostFromClient($client)->reset();
+        $readOriginal = $clusterHosts->read();
+        $this->assertCount(4, $readOriginal);
+
+        $clusterHosts->failed($readOriginal[0]);
+        $clusterHosts->failed($readOriginal[1]);
+        $readAfter2failed = $clusterHosts->read();
+
+        unset($client);
+
+        $client = Client::create();
+        $clusterHosts = $this->getClusterHostFromClient($client);
+        $readAfterReadingCache = $clusterHosts->read();
+
+        $this->assertCount(2, $readAfterReadingCache);
+        $this->assertEquals($this->hash($readAfter2failed), $this->hash($readAfterReadingCache));
+    }
+
+    public function getClusterHostFromClient($clientInstance)
+    {
+        $ref = new \ReflectionProperty('Algolia\AlgoliaSearch\Client', 'api');
+        $ref->setAccessible(true);
+        $apiWrapper = $ref->getValue($clientInstance);
+
+        $ref = new \ReflectionProperty('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper', 'clusterHosts');
+        $ref->setAccessible(true);
+
+        return $ref->getValue($apiWrapper);
+    }
+
+    private function hash(array $hosts)
+    {
+        return sha1(implode('', $hosts));
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | ¯\_(ツ)_/¯   
| Need Doc update   | yes


## Describe your change

I have added a cache mecanism. Restoring the feature that already exists in v1. The point is to store the state of Algolia hosts so if a server is down, you don't try it at every PHP request.

* Ideally, I'd like to ship a Redis driver as well. 
* We may want to add load testing.

### PSR-16

The cache driver must implement `CacheInterface` provided by PSR-16. It makes the cache easily swappable with a lot of libraries, although it adds a dependency and makes a a bit harder to install of you don't use composer (typically WordPress or Drupal < 7).