### PR TITLE
[RFC] Introduce Relevancy helpers

### DIFF
--- a/src/Relevancy/Ratings.php
+++ b/src/Relevancy/Ratings.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Relevancy;
+
+class Ratings
+{
+    public static function score($positive, $negative) {
+        return ((($positive + 1.9208) / ($positive + $negative) - 1.96 * sqrt((($positive * $negative) / ($positive + $negative)) + 0.9604) / ($positive + $negative)) / (1 + 3.8416 / ($positive + $negative)));
+    }
+
+    public static function fiveStarRating($one, $two, $three, $four, $five) {
+        $positive = $two * 0.25 + $three * 0.5 + $four * 0.75 + $five;
+        $negative = $one + $two * 0.75 + $three * 0.5 + $four * 0.25;
+
+        return self::score($positive, $negative);
+    }
+
+    public static function fiveStarRatingAverage($avg, $total)
+    {
+        $positive = ($avg * $total - $total) / 4;
+        $negative = $total - $positive;
+
+        return self::score($positive, $negative);
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | if merged


I'm thinking our client could go further and help with you relevancy.

If you want to sort by rating, you shouldn't sort by "average rating" or "number of ratings", you should use a ratio that takes both into account. Otherwise a product 1 one rating 5/5 will be shown before a product with 1000 rating but 4.9/5 on average.

You can read more about it here: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html

Because Algolia is a tie breaking algorithm, we should also round this number to create ties! (Not implemented in this PR)

Please share your thoughts. Note that this probably won't make it in the 2.0.0 release.