### PR TITLE
Introduce ResponseObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@
     
 * Remove Canary Client and Index
 
+* Introduce ResponseObjects
+    Every indexing operations returns an object with a `wait()` method.
+    The response from the API is still accessible as an array.
+    ```php
+    $response = $index->saveSynonym($synonym);
+    $response->wait();
+    echo $response['objectID'];
+    ```
+
 
 ### UNRELEASED
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,6 @@
 
 namespace Algolia\AlgoliaSearch;
 
-use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
-use Algolia\AlgoliaSearch\Exceptions\TaskTooLongException;
 use Algolia\AlgoliaSearch\Http\HttpClientFactory;
 use Algolia\AlgoliaSearch\Interfaces\ConfigInterface;
 use Algolia\AlgoliaSearch\Interfaces\ClientInterface;

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -9,7 +9,9 @@ abstract class AbstractConfig implements ConfigInterface
     protected $config;
 
     protected $defaultReadTimeout = 5;
+
     protected $defaultWriteTimeout = 5;
+
     protected $defaultConnectTimeout = 2;
 
     public function __construct(array $config = array())

--- a/src/Config/ClientConfig.php
+++ b/src/Config/ClientConfig.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Config;
 final class ClientConfig extends AbstractConfig
 {
     private $defaultWaitTaskTimeBeforeRetry = 100000;
+
     private $defaultWaitTaskMaxRetry = 30;
 
     public static function create($appId = null, $apiKey = null)

--- a/src/Exceptions/CannotWaitException.php
+++ b/src/Exceptions/CannotWaitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Exceptions;
+
+class CannotWaitException extends AlgoliaException
+{
+}

--- a/src/Exceptions/TaskTooLongException.php
+++ b/src/Exceptions/TaskTooLongException.php
@@ -4,9 +4,9 @@ namespace Algolia\AlgoliaSearch\Exceptions;
 
 class TaskTooLongException extends AlgoliaException
 {
-    public function __construct($message = "", $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $code = 0, \Exception $previous = null)
     {
-        if ("" === $message) {
+        if ('' === $message) {
             $message = 'Task took too long to complete. You can increase $waitTaskTimeBeforeRetry and $waitTaskMaxRetry in ClientConfig.';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Exceptions/TaskTooLongException.php
+++ b/src/Exceptions/TaskTooLongException.php
@@ -4,4 +4,11 @@ namespace Algolia\AlgoliaSearch\Exceptions;
 
 class TaskTooLongException extends AlgoliaException
 {
+    public function __construct($message = "", $code = 0, \Exception $previous = null)
+    {
+        if ("" === $message) {
+            $message = 'Task took too long to complete. You can increase $waitTaskTimeBeforeRetry and $waitTaskMaxRetry in ClientConfig.';
+        }
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -55,6 +55,7 @@ class Guzzle6HttpClient implements HttpClientInterface
             if ($e->hasResponse()) {
                 return $this->handleResponse($e->getResponse(), $request);
             }
+
             throw $this->handleException($e, $request);
         } catch (\Exception $e) {
             throw $this->handleException($e, $request);

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\UriInterface;
 class Php53HttpClient implements HttpClientInterface
 {
     private $curlMHandle = null;
+
     private $curlOptions;
 
     public function __construct($curlOptions = array())
@@ -28,6 +29,7 @@ class Php53HttpClient implements HttpClientInterface
         } elseif (is_string($uri)) {
             return new Uri($uri);
         }
+
         throw new \InvalidArgumentException('URI must be a string or UriInterface');
     }
 

--- a/src/Http/Psr7/BufferStream.php
+++ b/src/Http/Psr7/BufferStream.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\StreamInterface;
 class BufferStream implements StreamInterface
 {
     private $hwm;
+
     private $buffer = '';
 
     /**

--- a/src/Http/Psr7/Stream.php
+++ b/src/Http/Psr7/Stream.php
@@ -10,11 +10,17 @@ use Psr\Http\Message\StreamInterface;
 class Stream implements StreamInterface
 {
     private $stream;
+
     private $size;
+
     private $seekable;
+
     private $readable;
+
     private $writable;
+
     private $uri;
+
     private $customMetadata;
 
     /** @var array Hash of readable and writable stream types */

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -38,7 +38,9 @@ class Uri implements UriInterface
     );
 
     private static $charUnreserved = 'a-zA-Z0-9_\-\.~';
+
     private static $charSubDelims = '!\$&\'\(\)\*\+,;=';
+
     private static $replaceQuery = array('=' => '%3D', '&' => '%26');
 
     /** @var string Uri scheme. */

--- a/src/Http/Psr7/functions.php
+++ b/src/Http/Psr7/functions.php
@@ -34,6 +34,7 @@ function stream_for($resource = '', array $options = array())
             } elseif (method_exists($resource, '__toString')) {
                 return stream_for((string) $resource, $options);
             }
+
             break;
         case 'NULL':
             return new Stream(fopen('php://temp', 'r+'), $options);
@@ -41,6 +42,7 @@ function stream_for($resource = '', array $options = array())
     if (is_callable($resource)) {
         return new PumpStream($resource, $options);
     }
+
     throw new \InvalidArgumentException('Invalid resource type: '.gettype($resource));
 }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Exceptions\TaskTooLongException;
 use Algolia\AlgoliaSearch\Interfaces\ConfigInterface;
 use Algolia\AlgoliaSearch\Interfaces\IndexInterface;
+use Algolia\AlgoliaSearch\Response\IndexingResponse;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\Iterators\ObjectIterator;
@@ -56,12 +57,14 @@ class Index implements IndexInterface
 
     public function clear($requestOptions = array())
     {
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/clear', $this->indexName),
             array(),
             $requestOptions
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function getSettings($requestOptions = array())
@@ -86,13 +89,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'PUT',
             api_path('/1/indexes/%s/settings', $this->indexName),
             $settings,
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function getObject($objectId, $requestOptions = array())
@@ -187,7 +192,7 @@ class Index implements IndexInterface
 
         $this->saveObjects($objects, $requestOptions);
 
-        $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/operation', $this->indexName),
             array(
@@ -196,6 +201,8 @@ class Index implements IndexInterface
             ),
             $requestOptions
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function deleteObject($objectId, $requestOptions = array())
@@ -214,22 +221,26 @@ class Index implements IndexInterface
 
     public function deleteBy(array $args, $requestOptions = array())
     {
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/deleteByQuery', $this->indexName),
             array('params' => Helpers::buildQuery($args)),
             $requestOptions
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function batch($requests, $requestOptions = array())
     {
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/batch', $this->indexName),
             array('requests' => $requests),
             $requestOptions
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function browse($requestOptions = array())
@@ -275,13 +286,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/synonyms/batch', $this->indexName),
             $synonyms,
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function freshSynonyms($synonyms, $requestOptions = array())
@@ -302,13 +315,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'DELETE',
             api_path('/1/indexes/%s/synonyms/%s', $this->indexName, $objectId),
             array(),
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function clearSynonyms($requestOptions = array())
@@ -318,13 +333,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/synonyms/clear', $this->indexName),
             array(),
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function browseSynonyms($requestOptions = array())
@@ -370,13 +387,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/rules/batch', $this->indexName),
             $rules,
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function freshRules($rules, $requestOptions = array())
@@ -397,13 +416,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'DELETE',
             api_path('/1/indexes/%s/rules/%s', $this->indexName, $objectId),
             array(),
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function clearRules($requestOptions = array())
@@ -413,13 +434,15 @@ class Index implements IndexInterface
             $default['forwardToReplicas'] = $fwd;
         }
 
-        return $this->api->write(
+        $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/rules/clear', $this->indexName),
             array(),
             $requestOptions,
             $default
         );
+
+        return new IndexingResponse($response, $this);
     }
 
     public function browseRules($requestOptions = array())
@@ -473,11 +496,13 @@ class Index implements IndexInterface
 
     public function deleteDeprecatedIndexApiKey($key, $requestOptions = array())
     {
-        return $this->api->write(
+        $response = $this->api->write(
             'DELETE',
             api_path('/1/indexes/%s/keys/%s', $this->indexName, $key),
             array(),
             $requestOptions
         );
+
+        return new IndexingResponse($response, $this);
     }
 }

--- a/src/Places.php
+++ b/src/Places.php
@@ -7,7 +7,6 @@ use Algolia\AlgoliaSearch\Http\HttpClientFactory;
 use Algolia\AlgoliaSearch\Interfaces\ConfigInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
-use Algolia\AlgoliaSearch\Config\ClientConfig;
 
 final class Places
 {

--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+abstract class AbstractResponse implements \ArrayAccess
+{
+    /**
+     * @var array Full response from Algolia API
+     */
+    protected $apiResponse;
+
+    abstract public function wait($requestOptions = array());
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->apiResponse[$offset]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetGet($offset)
+    {
+        return $this->apiResponse[$offset];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->apiResponse[$offset] = $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->apiResponse[$offset]);
+    }
+}

--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -12,7 +12,7 @@ abstract class AbstractResponse implements \ArrayAccess
     abstract public function wait($requestOptions = array());
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function offsetExists($offset)
     {
@@ -20,7 +20,7 @@ abstract class AbstractResponse implements \ArrayAccess
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function offsetGet($offset)
     {
@@ -28,7 +28,7 @@ abstract class AbstractResponse implements \ArrayAccess
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function offsetSet($offset, $value)
     {
@@ -36,7 +36,7 @@ abstract class AbstractResponse implements \ArrayAccess
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function offsetUnset($offset)
     {

--- a/src/Response/AddApiKeyResponse.php
+++ b/src/Response/AddApiKeyResponse.php
@@ -13,6 +13,7 @@ class AddApiKeyResponse extends AbstractResponse
      * @var \Algolia\AlgoliaSearch\Interfaces\ClientInterface
      */
     private $client;
+
     /**
      * @var \Algolia\AlgoliaSearch\Config\ClientConfig
      */
@@ -41,6 +42,7 @@ class AddApiKeyResponse extends AbstractResponse
                 $this->client->getApiKey($key, $requestOptions);
 
                 unset($this->client, $this->config);
+
                 return $this;
             } catch (NotFoundException $e) {
                 // Try again

--- a/src/Response/AddApiKeyResponse.php
+++ b/src/Response/AddApiKeyResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+use Algolia\AlgoliaSearch\Config\ClientConfig;
+use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
+use Algolia\AlgoliaSearch\Exceptions\TaskTooLongException;
+use Algolia\AlgoliaSearch\Interfaces\ClientInterface;
+
+class AddApiKeyResponse extends AbstractResponse
+{
+    /**
+     * @var \Algolia\AlgoliaSearch\Interfaces\ClientInterface
+     */
+    private $client;
+    /**
+     * @var \Algolia\AlgoliaSearch\Config\ClientConfig
+     */
+    private $config;
+
+    public function __construct(array $apiResponse, ClientInterface $client, ClientConfig $config)
+    {
+        $this->apiResponse = $apiResponse;
+        $this->client = $client;
+        $this->config = $config;
+    }
+
+    public function wait($requestOptions = array())
+    {
+        if (!$this->client) {
+            return $this;
+        }
+
+        $key = $this->apiResponse['value'];
+        $retry = 1;
+        $maxRetry = $this->config->getWaitTaskMaxRetry();
+        $time = $this->config->getWaitTaskTimeBeforeRetry();
+
+        do {
+            try {
+                $this->client->getApiKey($key, $requestOptions);
+
+                unset($this->client, $this->config);
+                return $this;
+            } catch (NotFoundException $e) {
+                // Try again
+            }
+
+            $retry++;
+            $factor = ceil($retry / 10);
+            usleep($factor * $time); // 0.1 second
+        } while ($retry < $maxRetry);
+
+        throw new TaskTooLongException('The key '.substr($key, 0, 6)."... isn't added yet.");
+    }
+}

--- a/src/Response/DeleteApiKeyResponse.php
+++ b/src/Response/DeleteApiKeyResponse.php
@@ -40,9 +40,9 @@ class DeleteApiKeyResponse extends AbstractResponse
         do {
             try {
                 $this->client->getApiKey($key, $requestOptions);
-
             } catch (NotFoundException $e) {
                 unset($this->client, $this->config);
+
                 return $this;
             }
 

--- a/src/Response/DeleteApiKeyResponse.php
+++ b/src/Response/DeleteApiKeyResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
+use Algolia\AlgoliaSearch\Exceptions\TaskTooLongException;
+use Algolia\AlgoliaSearch\Config\ClientConfig;
+use Algolia\AlgoliaSearch\Interfaces\ClientInterface;
+
+class DeleteApiKeyResponse extends AbstractResponse
+{
+    /**
+     * @var \Algolia\AlgoliaSearch\Interfaces\ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var \Algolia\AlgoliaSearch\Config\ClientConfig
+     */
+    private $config;
+
+    public function __construct(array $apiResponse, ClientInterface $client, ClientConfig $config)
+    {
+        $this->apiResponse = $apiResponse;
+        $this->client = $client;
+        $this->config = $config;
+    }
+
+    public function wait($requestOptions = array())
+    {
+        if (!$this->client) {
+            return $this;
+        }
+
+        $key = $this->apiResponse['value'];
+        $retry = 1;
+        $maxRetry = $this->config->getWaitTaskMaxRetry();
+        $time = $this->config->getWaitTaskTimeBeforeRetry();
+
+        do {
+            try {
+                $this->client->getApiKey($key, $requestOptions);
+
+            } catch (NotFoundException $e) {
+                unset($this->client, $this->config);
+                return $this;
+            }
+
+            $retry++;
+            $factor = ceil($retry / 10);
+            usleep($factor * $time); // 0.1 second
+        } while ($retry < $maxRetry);
+
+        throw new TaskTooLongException('The key '.substr($key, 0, 6)."... isn't added yet.");
+    }
+}

--- a/src/Response/IndexingResponse.php
+++ b/src/Response/IndexingResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+use Algolia\AlgoliaSearch\Exceptions\CannotWaitException;
+use Algolia\AlgoliaSearch\Interfaces\IndexInterface;
+
+class IndexingResponse extends AbstractResponse
+{
+    /**
+     * @var \Algolia\AlgoliaSearch\Interfaces\IndexInterface
+     */
+    private $index;
+
+    public function __construct(array $apiResponse, IndexInterface $index)
+    {
+        $this->apiResponse = $apiResponse;
+        $this->index = $index;
+    }
+
+    public function wait($requestOptions = array())
+    {
+        if ($this->index) {
+            $this->index->waitTask($this->apiResponse['taskId'], $requestOptions);
+            unset($this->index);
+        }
+
+        return $this;
+    }
+}

--- a/src/Response/IndexingResponse.php
+++ b/src/Response/IndexingResponse.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Response;
 
-use Algolia\AlgoliaSearch\Exceptions\CannotWaitException;
 use Algolia\AlgoliaSearch\Interfaces\IndexInterface;
 
 class IndexingResponse extends AbstractResponse

--- a/src/Response/MultipleIndexingResponse.php
+++ b/src/Response/MultipleIndexingResponse.php
@@ -28,6 +28,7 @@ class MultipleIndexingResponse extends AbstractResponse
         }
 
         unset($this->client);
+
         return $this;
     }
 }

--- a/src/Response/MultipleIndexingResponse.php
+++ b/src/Response/MultipleIndexingResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+use Algolia\AlgoliaSearch\Interfaces\ClientInterface;
+
+class MultipleIndexingResponse extends AbstractResponse
+{
+    /**
+     * @var \Algolia\AlgoliaSearch\Interfaces\ClientInterface
+     */
+    private $client;
+
+    public function __construct(array $apiResponse, ClientInterface $client)
+    {
+        $this->apiResponse = $apiResponse;
+        $this->client = $client;
+    }
+
+    public function wait($requestOptions = array())
+    {
+        if (!$this->client) {
+            return $this;
+        }
+
+        foreach ($this->apiResponse['taskId'] as $indexName => $taskId) {
+            $this->client->waitTask($indexName, $taskId, $requestOptions);
+        }
+
+        unset($this->client);
+        return $this;
+    }
+}

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -123,6 +123,7 @@ class ApiWrapper
             $request = null;
             $logParams['retryNumber'] = $retry;
             $logParams['host'] = (string) $uri;
+
             try {
                 $request = $this->http->createRequest(
                     $method,

--- a/tests/API/MethodConsistentConstraint.php
+++ b/tests/API/MethodConsistentConstraint.php
@@ -33,6 +33,7 @@ class MethodConsistentConstraint extends \PHPUnit_Framework_Constraint
             if (!isset($definition['args'][$arg->getPosition()])) {
                 $success = false;
                 $description = 'The parameter '.$arg->getName().' #'.$arg->getPosition().' is missing in '.$definition['method'];
+
                 break;
             }
 
@@ -41,6 +42,7 @@ class MethodConsistentConstraint extends \PHPUnit_Framework_Constraint
             if ($arg->getName() !== $argDef['name']) {
                 $success = false;
                 $description = 'The parameter '.$arg->getName().' should be named '.$argDef['name'];
+
                 break;
             }
 
@@ -53,12 +55,14 @@ class MethodConsistentConstraint extends \PHPUnit_Framework_Constraint
                 if ($default != $argDef['default']) {
                     $success = false;
                     $description = 'The parameter '.$arg->getName().' should have '.print_r($argDef['default'], true).' as a default value';
+
                     break;
                 }
             } else {
                 if ($arg->isOptional()) {
                     $success = false;
                     $description = 'The parameter '.$arg->getName().' shouldn\'t have default value';
+
                     break;
                 }
             }

--- a/tests/API/PublicApiChecker.php
+++ b/tests/API/PublicApiChecker.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Assert;
 class PublicApiChecker extends Assert
 {
     private $instance;
+
     private $definition;
 
     public function __construct($instance, $definition)

--- a/tests/Integration/KeysTest.php
+++ b/tests/Integration/KeysTest.php
@@ -29,6 +29,7 @@ class KeysTest extends AlgoliaIntegrationTestCase
         $client->waitForKeyAdded($response['key']);
 
         $key = $client->getApiKey($response['key']);
+
         try {
             $this->assertArraySubset($this->keyParams, $key);
         } catch (\Exception $e) {
@@ -37,6 +38,7 @@ class KeysTest extends AlgoliaIntegrationTestCase
 
         $client->deleteApiKey($key['value']);
         sleep(5);
+
         try {
             $key = $client->getApiKey($key['value']);
             $this->assertTrue(false);

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -35,6 +35,7 @@ class SettingsTest extends AlgoliaIntegrationTestCase
     public function testSettingsWithReplicas()
     {
         $replica1 = self::safeName('settings-mgmt_REPLICA');
+
         try {
             static::getClient()->deleteIndex($replica1);
         } catch (\Exception $e) {

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Unit;
+
+use Algolia\AlgoliaSearch\Client;
+
+class ResponseObjectTest extends RequestTestCase
+{
+    public function testResponseObjectIsArrayAccessible()
+    {
+        $response = Client::get()->addApiKey(array());
+        $this->assertInstanceOf('Algolia\AlgoliaSearch\Response\AddApiKeyResponse', $response);
+        $this->assertTrue(method_exists($response, 'wait'));
+
+        $response = Client::get()->deleteApiKey('key');
+        $this->assertInstanceOf('Algolia\AlgoliaSearch\Response\DeleteApiKeyResponse', $response);
+        $this->assertTrue(method_exists($response, 'wait'));
+
+        $response = Client::get()->multipleBatchObjects(array());
+        $this->assertInstanceOf('Algolia\AlgoliaSearch\Response\MultipleIndexingResponse', $response);
+        $this->assertTrue(method_exists($response, 'wait'));
+    }
+
+    public function testIndexingResponse()
+    {
+        $i = Client::get()->initIndex('cool');
+
+        $this->assertInstanceOfIndexingResponse($i->clear());
+        $this->assertInstanceOfIndexingResponse($i->setSettings(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->saveObject(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->saveObjects(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->partialUpdateObject(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->partialUpdateObjects(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->partialUpdateOrCreateObject(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->partialUpdateOrCreateObjects(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->freshObjects(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->deleteObject(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->deleteObjects(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->deleteBy(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->batch(array('objectID' => 'test')));
+
+        $this->assertInstanceOfIndexingResponse($i->saveSynonym(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->saveSynonyms(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->freshSynonyms(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->deleteSynonym('objectID'));
+        $this->assertInstanceOfIndexingResponse($i->clearSynonyms(array('objectID' => 'test')));
+
+        $this->assertInstanceOfIndexingResponse($i->saveRule(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->saveRules(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->freshRules(array('objectID' => 'test')));
+        $this->assertInstanceOfIndexingResponse($i->deleteRule('objectID'));
+        $this->assertInstanceOfIndexingResponse($i->clearRules(array('objectID' => 'test')));
+
+        $this->assertInstanceOfIndexingResponse($i->deleteDeprecatedIndexApiKey("key"));
+    }
+
+    private function assertInstanceOfIndexingResponse($response)
+    {
+        $this->assertInstanceOf('Algolia\AlgoliaSearch\Response\IndexingResponse', $response);
+        $this->assertTrue(method_exists($response, 'wait'));
+    }
+}

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -51,7 +51,7 @@ class ResponseObjectTest extends RequestTestCase
         $this->assertInstanceOfIndexingResponse($i->deleteRule('objectID'));
         $this->assertInstanceOfIndexingResponse($i->clearRules(array('objectID' => 'test')));
 
-        $this->assertInstanceOfIndexingResponse($i->deleteDeprecatedIndexApiKey("key"));
+        $this->assertInstanceOfIndexingResponse($i->deleteDeprecatedIndexApiKey('key'));
     }
 
     private function assertInstanceOfIndexingResponse($response)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes if you use `is_array` on indexing response
| Need Doc update   | yes


## Describe your change

Every indexing operations returns an object with a `wait()` method. The response from the API is **still accessible as an array**.

```php
$response = $index->saveSynonym($synonym);
$response.wait();
echo $response['objectID'];

$response = $cliebt->addApiKey();
$response.wait();
echo $response['value'];
```

## What problem is this fixing?

It makes waiting pretty cool. It's now consistant, whether you're waiting for a new API key or a standard indexing operations.

## To be tested

In order to wait, I inject the client or the index inside the response. I'm afraid of the consequenses on memory consumption. 
I unset the client or index at the end of a successful `wait()` call, as a small optimisation.

I'm definitely open to feedback on this one 👍 