### PR TITLE
Handle string[] for hosts in config

### DIFF
--- a/src/RetryStrategy/ClusterHosts.php
+++ b/src/RetryStrategy/ClusterHosts.php
@@ -36,6 +36,14 @@ class ClusterHosts
             $write = array($write => 0);
         }
 
+        if (array_values($read) === $read) {
+            $read = array_fill_keys($read, 0);
+        }
+
+        if (array_values($write) === $write) {
+            $write = array_fill_keys($write, 0);
+        }
+
         return new static(HostCollection::create($read), HostCollection::create($write));
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes/no
| New feature?      | yes/no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

The following example didn't work, it now works:

```php
$config = new ClientConfig();
$config->setHosts(["custom.algolia.com"]); // <- pass string, array of string or array like ["host" => $priority];
$client = Client::createWithConfig($config);
```

