### PR TITLE
HttpClientInterface only requires sendRequest method!

### DIFF
--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -10,7 +10,6 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -21,27 +20,6 @@ class Guzzle6HttpClient implements HttpClientInterface
     public function __construct(GuzzleClient $client = null)
     {
         $this->client = $client ?: static::buildClient();
-    }
-
-    public function createUri($uri)
-    {
-        return \GuzzleHttp\Psr7\uri_for($uri);
-    }
-
-    public function createRequest(
-        $method,
-        $uri,
-        array $headers = array(),
-        $body = null,
-        $protocolVersion = '1.1'
-    ) {
-        if (is_array($body)) {
-            // Send an empty body instead of "[]" in case there are
-            // no content/params to send
-            $body = empty($body) ? '' : \GuzzleHttp\json_encode($body);
-        }
-
-        return new Request($method, $uri, $headers, $body, $protocolVersion);
     }
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -6,15 +6,5 @@ use Psr\Http\Message\RequestInterface;
 
 interface HttpClientInterface
 {
-    public function createUri($uri);
-
-    public function createRequest(
-        $method,
-        $uri,
-        array $headers = array(),
-        $body = null,
-        $protocolVersion = '1.1'
-    );
-
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout);
 }

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -6,51 +6,17 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\Exceptions\RetriableException;
-use Algolia\AlgoliaSearch\Http\Psr7\Request;
-use Algolia\AlgoliaSearch\Http\Psr7\Uri;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\UriInterface;
 
 class Php53HttpClient implements HttpClientInterface
 {
-    private $curlMHandle = null;
+    private $curlMHandle;
 
     private $curlOptions;
 
     public function __construct($curlOptions = array())
     {
         $this->curlOptions = $curlOptions;
-    }
-
-    public function createUri($uri)
-    {
-        if ($uri instanceof UriInterface) {
-            return $uri;
-        } elseif (is_string($uri)) {
-            return new Uri($uri);
-        }
-
-        throw new \InvalidArgumentException('URI must be a string or UriInterface');
-    }
-
-    public function createRequest(
-        $method,
-        $uri,
-        array $headers = array(),
-        $body = null,
-        $protocolVersion = '1.1'
-    ) {
-        if (is_array($body)) {
-            // Send an empty body instead of "[]" in case there are
-            // no content/params to send
-            $body = empty($body) ? '' : \json_encode($body);
-            if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new \InvalidArgumentException(
-                    'json_encode error: '.json_last_error_msg());
-            }
-        }
-
-        return new Request($method, $uri, $headers, $body, $protocolVersion);
     }
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | YES - httpClient Interface changed     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

When I wrote the `HttpClientInterface`, I added 3 methods, but createUri and createRequest never belonged there, I just got confused because they were provided by guzzle and that I had to maintain a different implementation for PHP 5.3

In the end createUri and createRequest have become as private methods of `ApiWrapper` 🎉 


### REMEMBER TO CHANGE BASE BRANCH BEFORE MERGING THIS PR
