### PR TITLE
Singleton reads credentials from env

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -36,10 +36,10 @@ class Client implements ClientInterface
         $this->config = $config;
     }
 
-    public static function get($appId = null, $apiKey = null)
+    public static function get()
     {
         if (!static::$client) {
-            static::$client = static::create($appId, $apiKey);
+            static::$client = static::create();
         }
 
         return static::$client;


### PR DESCRIPTION
	Otherwise we'll have to maintain one instance per credentials tuple
	Before this fix, if you call Client::get($app1, $key1) and then
	Client::get($app2, $key2), the second call will return client using
	credentials passed in the first call.

	We volontarily choose to only allow the use of singleton via the
	ALGOLIA_APP_ID and ALGOLIA_API_KEY env vars.
