### PR TITLE
Install Guzzle if platform is compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - php: 5.3
       dist: precise
-      env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
     - php: 5.6
       dist: trusty
       sudo: required
@@ -33,7 +32,6 @@ cache:
 
 install:
   - composer install
-  - if [ "$LEGACY_HTTP" != "true" ]; then composer require guzzlehttp/guzzle ; fi
 
 before_script:
   - wget https://alg.li/algolia-keys && chmod +x algolia-keys

--- a/bin/algolia-deps
+++ b/bin/algolia-deps
@@ -1,0 +1,44 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This script will automatically require guzzle library if your
+ * setup is compatible.
+ * If you don't want to use it, you can remove it with
+ *  `composer remove guzzlehttp/guzzle`
+ *
+ * Setting a LEGACY_HTTP=true in your environment variable will
+ * prevent the installation of guzzle.
+ *
+ * Note that it's *HIGHLY* recommended to use it.
+ */
+
+if (getenv('LEGACY_HTTP') || PHP_VERSION_ID < 50500) {
+    exit(0);
+}
+
+if ('composer.json' !== $COMPOSER_JSON = getenv('COMPOSER') ?: 'composer.json') {
+    putenv('COMPOSER=composer.json');
+    $_SERVER['COMPOSER'] = $_ENV['COMPOSER'] = 'composer.json';
+}
+
+$root = __DIR__;
+while (!file_exists($root.'/'.$COMPOSER_JSON) || file_exists($root.'vendor/bin/algolia-doctor')) {
+    if ($root === dirname($root)) {
+        break;
+    }
+    $root = dirname($root);
+}
+dump($root);
+
+$oldPwd = getcwd();
+$PHP = 'php';
+if ('phpdbg' === PHP_SAPI) {
+    $PHP .= ' -qrr';
+}
+
+$COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar') || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar 2> /dev/null`))
+    ? $PHP.' '.escapeshellarg($COMPOSER)
+    : 'composer';
+
+passthru("$COMPOSER require guzzlehttp/guzzle");

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,23 @@
             "Algolia\\AlgoliaSearch\\Tests\\": "tests"
         }
     },
-    "suggest": {
-        "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
-    },
     "bin": [
-        "bin/algolia-doctor"
+        "bin/algolia-doctor",
+        "bin/algolia-deps"
     ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "preferred-install": "dist"
+    },
+    "scripts": {
+        "post-package-install": [
+            "php vendor/bin/algolia-deps"
+        ],
+        "post-package-update": [
+            "php vendor/bin/algolia-deps"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

After composer update, this script will check the current setup and install guzzle if PHP > 5 and no `LEGACY_HTTP` env var was found.

We cannot require guzzle because we need to support 5.3. I found this solution better and easier to maintain than having a separate package with HttpClient adapters and different dependencies.
see: https://stackoverflow.com/questions/51333587/php-composer-require-dependency-if-condition