### PR TITLE
Fresh objects is not ready for production yet

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -173,37 +173,6 @@ class Index implements IndexInterface
         return $this->batch(Helpers::buildBatch($objects, 'partialUpdateObject'), $requestOptions);
     }
 
-    public function freshObjects($objects, $requestOptions = array())
-    {
-        $tmpName = $this->indexName.'_tmp_'.uniqid('php_', true);
-
-        // TODO: Replica!
-        $this->api->write(
-            'POST',
-            api_path('/1/indexes/%s/operation', $this->indexName),
-            array(
-                'operation' => 'copy',
-                'destination' => $tmpName,
-                'scope' => array('settings', 'synonyms', 'rules'),
-            ),
-            $requestOptions
-        );
-
-        $this->saveObjects($objects, $requestOptions);
-
-        $response = $this->api->write(
-            'POST',
-            api_path('/1/indexes/%s/operation', $this->indexName),
-            array(
-                'operation' => 'move',
-                'destination' => $tmpName,
-            ),
-            $requestOptions
-        );
-
-        return new IndexingResponse($response, $this);
-    }
-
     public function deleteObject($objectId, $requestOptions = array())
     {
         return $this->deleteObjects(array($objectId), $requestOptions);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes, removed function     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

This function was meant to help with atomic reindexing, I don't think it's ready for production yet, especially since we don't have any effecient way to grab data (see #420).

We'll add this feature later.
