### PR TITLE
Rename clear and browse for consistency

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -162,7 +162,7 @@ class Client implements ClientInterface
 
     public function clearIndex($indexName, $requestOptions = array())
     {
-        return $this->initIndex($indexName)->clear($requestOptions);
+        return $this->initIndex($indexName)->clearObjects($requestOptions);
     }
 
     public function deleteIndex($indexName, $requestOptions = array())

--- a/src/Index.php
+++ b/src/Index.php
@@ -56,18 +56,6 @@ class Index implements IndexInterface
         return $this->api->read('POST', api_path('/1/indexes/%s/query', $this->indexName), $requestOptions);
     }
 
-    public function clear($requestOptions = array())
-    {
-        $response = $this->api->write(
-            'POST',
-            api_path('/1/indexes/%s/clear', $this->indexName),
-            array(),
-            $requestOptions
-        );
-
-        return new IndexingResponse($response, $this);
-    }
-
     public function move($newIndexName, $requestOptions = array())
     {
         $response = $this->api->write(
@@ -218,6 +206,18 @@ class Index implements IndexInterface
         return new IndexingResponse($response, $this);
     }
 
+    public function clearObjects($requestOptions = array())
+    {
+        $response = $this->api->write(
+            'POST',
+            api_path('/1/indexes/%s/clear', $this->indexName),
+            array(),
+            $requestOptions
+        );
+
+        return new IndexingResponse($response, $this);
+    }
+
     public function batch($requests, $requestOptions = array())
     {
         $response = $this->api->write(
@@ -230,7 +230,7 @@ class Index implements IndexInterface
         return new IndexingResponse($response, $this);
     }
 
-    public function browse($requestOptions = array())
+    public function browseObjects($requestOptions = array())
     {
         return new ObjectIterator($this->indexName, $this->api, $requestOptions);
     }

--- a/src/Interfaces/IndexInterface.php
+++ b/src/Interfaces/IndexInterface.php
@@ -6,8 +6,6 @@ interface IndexInterface
 {
     public function search($query, $requestOptions = array());
 
-    public function clear($requestOptions = array());
-
     public function move($newIndexName, $requestOptions = array());
 
     public function getSettings($requestOptions = array());
@@ -36,9 +34,11 @@ interface IndexInterface
 
     public function deleteBy(array $args, $requestOptions = array());
 
+    public function clearObjects($requestOptions = array());
+
     public function batch($requests, $requestOptions = array());
 
-    public function browse($requestOptions = array());
+    public function browseObjects($requestOptions = array());
 
     public function searchSynonyms($query, $requestOptions = array());
 

--- a/tests/API/index.yaml
+++ b/tests/API/index.yaml
@@ -8,7 +8,7 @@
   - name: requestOptions
     default: []
 -
-  method: clear
+  method: clearObjects
   args:
   - name: requestOptions
     default: []

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -27,7 +27,7 @@ class ResponseObjectTest extends NullTestCase
     {
         $i = static::$client->initIndex('cool');
 
-        $this->assertInstanceOfIndexingResponse($i->clear());
+        $this->assertInstanceOfIndexingResponse($i->clearObjects());
         $this->assertInstanceOfIndexingResponse($i->rename('new-name'));
 
         $this->assertInstanceOfIndexingResponse($i->setSettings(array('objectID' => 'test')));


### PR DESCRIPTION
For consistency, I renamed the following:

| Before | After |
|--------|------|
| `Index::clear()` | `Index::clearObjects()` |
| `Index::browse()` |  `Index::browseObjects()` | 

If merge, upgrade guide should be updated #467 