### PR TITLE
Return behaviour of Index::waitTask to pre-1.27.0

### DIFF
--- a/src/AlgoliaSearch/Index.php
+++ b/src/AlgoliaSearch/Index.php
@@ -946,7 +946,7 @@ class Index
     {
         $requestHeaders = func_num_args() === 3 && is_array(func_get_arg(2)) ? func_get_arg(2) : array();
 
-        $this->client->waitTask($this->indexName, $taskID, $timeBeforeRetry, $requestHeaders);
+        return $this->client->waitTask($this->indexName, $taskID, $timeBeforeRetry, $requestHeaders);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Revert the behaviour of AlgoliaSearch\Index::waitTask to return the taskStatus response.

## What problem is this fixing?

v1.27.0 removed the `return`, this is just adding it back in.