### PR TITLE
Fixed listIndices name (was still listIndexes)

### DIFF
--- a/docs/UPGRADE-from-v1-to-v2.md
+++ b/docs/UPGRADE-from-v1-to-v2.md
@@ -36,7 +36,7 @@ so it's not used a lot, it's ignored for clarity purpose.
 
 |    | v1 | v2 |
 |----|----|----|
-| ✅ | `listIndexes()`         | `listIndexes($requestOptions = array())` |
+| 🤞 | `listIndexes()`         | `listIndices($requestOptions = array())` |
 | ✅ | `deleteIndex($indexName)`         | `deleteIndex($indexName, $requestOptions = array())` |
 | ✅ | `moveIndex($srcIndexName, $dstIndexName)`         | `moveIndex($srcIndexName, $dstIndexName, $requestOptions = array())` |
 | ✅ | `copyIndex($srcIndexName, $dstIndexName)`         | `copyIndex($srcIndexName, $dstIndexName, $requestOptions = array())` |

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -125,7 +125,7 @@ class SearchClient
         );
     }
 
-    public function listIndexes($requestOptions = array())
+    public function listIndices($requestOptions = array())
     {
         return $this->api->read('GET', api_path('/1/indexes/'), $requestOptions);
     }

--- a/tests/API/client.yaml
+++ b/tests/API/client.yaml
@@ -10,7 +10,7 @@
 # SearchIndex Management
 #
 -
-  method: listIndexes
+  method: listIndices
   args:
     - name: requestOptions
       default: []

--- a/tests/Integration/IndexManagementTest.php
+++ b/tests/Integration/IndexManagementTest.php
@@ -24,12 +24,12 @@ class IndexManagementTest extends AlgoliaIntegrationTestCase
     public function testListIndexes()
     {
         $client = static::getClient();
-        $list = $client->listIndexes();
+        $list = $client->listIndices();
         $this->assertArrayHasKey('items', $list);
         $this->assertEquals(1, $list['nbPages']);
 
         $nbPages = ceil(count($list['items']) / 100);
-        $list = $client->listIndexes(array('page' => 1));
+        $list = $client->listIndices(array('page' => 1));
         $this->assertEquals($nbPages, $list['nbPages']);
     }
 
@@ -93,7 +93,7 @@ class IndexManagementTest extends AlgoliaIntegrationTestCase
 
     private function assertIndexExists($indexName)
     {
-        $list = static::getClient()->listIndexes();
+        $list = static::getClient()->listIndices();
         foreach ($list['items'] as $index) {
             if ($index['name'] === $indexName) {
                 $this->assertTrue(true);
@@ -107,7 +107,7 @@ class IndexManagementTest extends AlgoliaIntegrationTestCase
 
     private function assertIndexDoesNotExist($indexName)
     {
-        $list = static::getClient()->listIndexes();
+        $list = static::getClient()->listIndices();
         foreach ($list['items'] as $index) {
             if ($index['name'] === $indexName) {
                 $this->assertTrue(false);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes     
| Need Doc update   | no


## Describe your change

The method `listIndexes` was renamed `listIndices`, this is how it was documented: https://deploy-preview-2021--algolia-doc.netlify.com/doc/api-reference/api-methods/list-indices/

Unfortunately, I didn't change the name properly in the client.  😩 
I realized that looking at @vinkla's PR https://github.com/vinkla/laravel-algolia/pull/12
