### PR TITLE
Define public API better

### DIFF
--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -8,7 +8,7 @@ use Algolia\AlgoliaSearch\Log\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 
-class Algolia
+final class Algolia
 {
     const VERSION = '2.0.0';
 

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -5,12 +5,13 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\AnalyticsConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 final class AnalyticsClient
 {
     /**
-     * @var ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -19,7 +20,7 @@ final class AnalyticsClient
      */
     private $config;
 
-    public function __construct(ApiWrapper $api, AnalyticsConfig $config)
+    public function __construct(ApiWrapperInterface $api, AnalyticsConfig $config)
     {
         $this->api = $api;
         $this->config = $config;

--- a/src/Cache/FileCacheDriver.php
+++ b/src/Cache/FileCacheDriver.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class FileCacheDriver implements CacheInterface
+final class FileCacheDriver implements CacheInterface
 {
     const PREFIX = 'algolia-client-';
 

--- a/src/Cache/NullCacheDriver.php
+++ b/src/Cache/NullCacheDriver.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class NullCacheDriver implements CacheInterface
+final class NullCacheDriver implements CacheInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Config/AnalyticsConfig.php
+++ b/src/Config/AnalyticsConfig.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Config;
 
-class AnalyticsConfig extends AbstractConfig
+final class AnalyticsConfig extends AbstractConfig
 {
     public static function create($appId = null, $apiKey = null)
     {

--- a/src/Config/PlacesConfig.php
+++ b/src/Config/PlacesConfig.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Config;
 
-class PlacesConfig extends AbstractConfig
+final class PlacesConfig extends AbstractConfig
 {
     public static function create($appId, $apiKey)
     {

--- a/src/Config/SearchConfig.php
+++ b/src/Config/SearchConfig.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Config;
 
-final class SearchConfig extends AbstractConfig
+class SearchConfig extends AbstractConfig
 {
     private $defaultWaitTaskTimeBeforeRetry = 100000;
 

--- a/src/Exceptions/CannotWaitException.php
+++ b/src/Exceptions/CannotWaitException.php
@@ -2,6 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Exceptions;
 
-class CannotWaitException extends AlgoliaException
+final class CannotWaitException extends AlgoliaException
 {
 }

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Exceptions;
 
-class NotFoundException extends BadRequestException
+final class NotFoundException extends BadRequestException
 {
 }

--- a/src/Exceptions/RetriableException.php
+++ b/src/Exceptions/RetriableException.php
@@ -2,6 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Exceptions;
 
-class RetriableException extends RequestException
+final class RetriableException extends RequestException
 {
 }

--- a/src/Exceptions/UnreachableException.php
+++ b/src/Exceptions/UnreachableException.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Exceptions;
 
-class UnreachableException extends AlgoliaException
+final class UnreachableException extends AlgoliaException
 {
     public function __construct($message = '', $code = 0, $previous = null)
     {

--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -8,7 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;
 
-class Guzzle6HttpClient implements HttpClientInterface
+final class Guzzle6HttpClient implements HttpClientInterface
 {
     private $client;
 

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\RetriableException;
 use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 
-class Php53HttpClient implements HttpClientInterface
+final class Php53HttpClient implements HttpClientInterface
 {
     private $curlMHandle;
 

--- a/src/Http/Psr7/BufferStream.php
+++ b/src/Http/Psr7/BufferStream.php
@@ -11,6 +11,8 @@ use Psr\Http\Message\StreamInterface;
  * This stream returns a "hwm" metadata value that tells upstream consumers
  * what the configured high water mark of the stream is, or the maximum
  * preferred size of the buffer.
+ *
+ * @internal
  */
 class BufferStream implements StreamInterface
 {

--- a/src/Http/Psr7/PumpStream.php
+++ b/src/Http/Psr7/PumpStream.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\StreamInterface;
  * returned by the provided callable is buffered internally until drained using
  * the read() function of the PumpStream. The provided callable MUST return
  * false when there is no more data to read.
+ *
+ * @internal
  */
 class PumpStream implements StreamInterface
 {

--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * PSR-7 request implementation.
+ *
+ * @internal
  */
 class Request implements RequestInterface
 {

--- a/src/Http/Psr7/Response.php
+++ b/src/Http/Psr7/Response.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\StreamInterface;
  *
  * This class was modified to support PHP 5.3,
  * same for all the classes under PSR7 folder.
+ *
+ * @internal
  */
 class Response implements ResponseInterface
 {

--- a/src/Http/Psr7/Stream.php
+++ b/src/Http/Psr7/Stream.php
@@ -6,6 +6,8 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * PHP stream implementation.
+ *
+ * @internal
  */
 class Stream implements StreamInterface
 {

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -12,6 +12,8 @@ use Psr\Http\Message\UriInterface;
  * @author Matthew Weier O'Phinney
  *
  * Adapted for PHP 5.3 by Algolia.
+ *
+ * @internal
  */
 class Uri implements UriInterface
 {

--- a/src/Http/Psr7/UriResolver.php
+++ b/src/Http/Psr7/UriResolver.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\UriInterface;
  * @author Tobias Schultze
  *
  * @see https://tools.ietf.org/html/rfc3986#section-5
+ *
+ * @internal
  */
 final class UriResolver
 {

--- a/src/Http/Psr7/functions.php
+++ b/src/Http/Psr7/functions.php
@@ -4,6 +4,9 @@ namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 
+/**
+ * @internal
+ */
 function stream_for($resource = '', array $options = array())
 {
     if (is_scalar($resource)) {
@@ -46,6 +49,9 @@ function stream_for($resource = '', array $options = array())
     throw new \InvalidArgumentException('Invalid resource type: '.gettype($resource));
 }
 
+/**
+ * @internal
+ */
 function copy_to_string(StreamInterface $stream, $maxLen = -1)
 {
     $buffer = '';

--- a/src/Iterators/ObjectIterator.php
+++ b/src/Iterators/ObjectIterator.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;
 
-class ObjectIterator extends AbstractAlgoliaIterator
+final class ObjectIterator extends AbstractAlgoliaIterator
 {
     public function getCursor()
     {

--- a/src/Iterators/RuleIterator.php
+++ b/src/Iterators/RuleIterator.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;
 
-class RuleIterator extends AbstractAlgoliaIterator
+final class RuleIterator extends AbstractAlgoliaIterator
 {
     protected function formatHit(array $hit)
     {

--- a/src/Iterators/SynonymIterator.php
+++ b/src/Iterators/SynonymIterator.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;
 
-class SynonymIterator extends AbstractAlgoliaIterator
+final class SynonymIterator extends AbstractAlgoliaIterator
 {
     protected function formatHit(array $hit)
     {

--- a/src/PlacesClient.php
+++ b/src/PlacesClient.php
@@ -5,12 +5,13 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\PlacesConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 final class PlacesClient
 {
     /**
-     * @var ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -19,7 +20,7 @@ final class PlacesClient
      */
     private $config;
 
-    public function __construct(ApiWrapper $api, PlacesConfig $config)
+    public function __construct(ApiWrapperInterface $api, PlacesConfig $config)
     {
         $this->api = $api;
         $this->config = $config;

--- a/src/RequestOptions/RequestOptions.php
+++ b/src/RequestOptions/RequestOptions.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\RequestOptions;
 
 use Algolia\AlgoliaSearch\Support\Helpers;
 
-class RequestOptions
+final class RequestOptions
 {
     private $headers = array();
 

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -5,7 +5,7 @@ namespace Algolia\AlgoliaSearch\RequestOptions;
 use Algolia\AlgoliaSearch\Config\AbstractConfig;
 use Algolia\AlgoliaSearch\Support\UserAgent;
 
-class RequestOptionsFactory
+final class RequestOptionsFactory
 {
     private $config;
 

--- a/src/Response/AddApiKeyResponse.php
+++ b/src/Response/AddApiKeyResponse.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\SearchClient;
 
-class AddApiKeyResponse extends AbstractResponse
+final class AddApiKeyResponse extends AbstractResponse
 {
     /**
      * @var \Algolia\AlgoliaSearch\SearchClient

--- a/src/Response/DeleteApiKeyResponse.php
+++ b/src/Response/DeleteApiKeyResponse.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\SearchClient;
 
-class DeleteApiKeyResponse extends AbstractResponse
+final class DeleteApiKeyResponse extends AbstractResponse
 {
     /**
      * @var \Algolia\AlgoliaSearch\Config\SearchConfig

--- a/src/Response/IndexingObjectsResponse.php
+++ b/src/Response/IndexingObjectsResponse.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchIndex;
 
-class IndexingObjectsResponse extends AbstractResponse implements \Iterator, \Countable
+final class IndexingObjectsResponse extends AbstractResponse implements \Iterator, \Countable
 {
     /**
      * @var \Algolia\AlgoliaSearch\SearchIndex

--- a/src/Response/IndexingResponse.php
+++ b/src/Response/IndexingResponse.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchIndex;
 
-class IndexingResponse extends AbstractResponse
+final class IndexingResponse extends AbstractResponse
 {
     /**
      * @var \Algolia\AlgoliaSearch\SearchIndex

--- a/src/Response/MultipleIndexingResponse.php
+++ b/src/Response/MultipleIndexingResponse.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchClient;
 
-class MultipleIndexingResponse extends AbstractResponse
+final class MultipleIndexingResponse extends AbstractResponse
 {
     /**
      * @var \Algolia\AlgoliaSearch\SearchClient

--- a/src/Response/UpdateApiKeyResponse.php
+++ b/src/Response/UpdateApiKeyResponse.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\SearchClient;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 
-class UpdateApiKeyResponse extends AbstractResponse
+final class UpdateApiKeyResponse extends AbstractResponse
 {
     /**
      * @var \Algolia\AlgoliaSearch\SearchClient

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LogLevel;
 
-class ApiWrapper
+final class ApiWrapper implements ApiWrapperInterface
 {
     /**
      * @var HttpClientInterface

--- a/src/RetryStrategy/ApiWrapperInterface.php
+++ b/src/RetryStrategy/ApiWrapperInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\RetryStrategy;
+
+interface ApiWrapperInterface
+{
+    public function read($method, $path, $requestOptions = array(), $defaultRequestOptions = array());
+
+    public function write($method, $path, $data = array(), $requestOptions = array(), $defaultRequestOptions = array());
+
+    public function send($method, $path, $requestOptions = array(), $hosts = null);
+}

--- a/src/RetryStrategy/ClusterHosts.php
+++ b/src/RetryStrategy/ClusterHosts.php
@@ -4,7 +4,10 @@ namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 use Algolia\AlgoliaSearch\Algolia;
 
-class ClusterHosts
+/**
+ * @internal
+ */
+final class ClusterHosts
 {
     private $read;
 

--- a/src/RetryStrategy/Host.php
+++ b/src/RetryStrategy/Host.php
@@ -2,7 +2,10 @@
 
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
-class Host
+/**
+ * @internal
+ */
+final class Host
 {
     private $url;
 

--- a/src/RetryStrategy/HostCollection.php
+++ b/src/RetryStrategy/HostCollection.php
@@ -2,7 +2,10 @@
 
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
-class HostCollection
+/**
+ * @internal
+ */
+final class HostCollection
 {
     private $hosts;
 

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -6,8 +6,9 @@ use Algolia\AlgoliaSearch\Response\DeleteApiKeyResponse;
 use Algolia\AlgoliaSearch\Response\MultipleIndexingResponse;
 use Algolia\AlgoliaSearch\Response\AddApiKeyResponse;
 use Algolia\AlgoliaSearch\Response\UpdateApiKeyResponse;
-use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Support\Helpers;
@@ -15,7 +16,7 @@ use Algolia\AlgoliaSearch\Support\Helpers;
 class SearchClient
 {
     /**
-     * @var ApiWrapper
+     * @var ApiWrapperInterface
      */
     protected $api;
 
@@ -26,7 +27,7 @@ class SearchClient
 
     protected static $client;
 
-    public function __construct(ApiWrapper $apiWrapper, SearchConfig $config)
+    public function __construct(ApiWrapperInterface $apiWrapper, SearchConfig $config)
     {
         $this->api = $apiWrapper;
         $this->config = $config;

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -4,7 +4,7 @@ namespace Algolia\AlgoliaSearch\Support;
 
 use Algolia\AlgoliaSearch\Exceptions\MissingObjectId;
 
-class Helpers
+final class Helpers
 {
     /**
      * Use this function to generate API path. It will ensure


### PR DESCRIPTION
We added final on many classes and @internal tags on code
that shouldn't be used

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | compare to RC, could be     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

Many classes are now final and some are tagged `@internal`. All `@internal` classes should be used, they could break at some point.

If you need to extend a class we marked as `final`, please let us know, there could be good reasons we missed.
