### PR TITLE
Fixes issue while sending an empty batch

### DIFF
--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -372,10 +372,12 @@ class SearchIndex
             }
         }
 
-        if ('addObject' !== $action) {
-            Helpers::ensureObjectID($batch, 'All objects must have an unique objectID (like a primary key) to be valid.');
+        if (! empty($batch)) {
+            if ('addObject' !== $action) {
+                Helpers::ensureObjectID($batch, 'All objects must have an unique objectID (like a primary key) to be valid.');
+            }
+            $allResponses[] = $this->rawBatch(Helpers::buildBatch($batch, $action), $requestOptions);
         }
-        $allResponses[] = $this->rawBatch(Helpers::buildBatch($batch, $action), $requestOptions);
 
         return new IndexingObjectsResponse($allResponses, $this);
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

The response `status` in a `POST` of an empty batch I will be always be `notPublished`, causing an issue while `wait()` this response.