### PR TITLE
Keeps replicas settings after reindex

### DIFF
--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -717,7 +717,7 @@ class SearchIndex
         $allResponses[] = $moveResponse;
 
         if ($replicas) {
-            $allResponses[] = $this->setSettings(array('replicas' => false));
+            $allResponses[] = $this->setSettings(array('replicas' => $settings));
         }
 
         return $allResponses;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## What problem is this fixing?

After calling the method `reindex` on the SearchIndex class, the `replicas` setting is not preserved.

**Note**: We should consider adding tests to this method.