### PR TITLE
Fix json_encode error detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 /vendor/
 .php_cs.cache
 /tests/cache/
+.idea/

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -231,7 +231,7 @@ final class ApiWrapper implements ApiWrapperInterface
                 $body = \json_encode($body);
                 if (JSON_ERROR_NONE !== json_last_error()) {
                     throw new \InvalidArgumentException(
-                        'json_encode error: ' . json_last_error_msg());
+                        'json_encode error: '.json_last_error_msg());
                 }
             }
         }

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -225,10 +225,14 @@ final class ApiWrapper implements ApiWrapperInterface
         if (is_array($body)) {
             // Send an empty body instead of "[]" in case there are
             // no content/params to send
-            $body = empty($body) ? '' : \json_encode($body);
-            if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new \InvalidArgumentException(
-                    'json_encode error: '.json_last_error_msg());
+            if (empty($body)) {
+                $body = '';
+            } else {
+                \json_encode($body);
+                if (JSON_ERROR_NONE !== json_last_error()) {
+                    throw new \InvalidArgumentException(
+                        'json_encode error: ' . json_last_error_msg());
+                }
             }
         }
 

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -228,7 +228,7 @@ final class ApiWrapper implements ApiWrapperInterface
             if (empty($body)) {
                 $body = '';
             } else {
-                \json_encode($body);
+                $body = \json_encode($body);
                 if (JSON_ERROR_NONE !== json_last_error()) {
                     throw new \InvalidArgumentException(
                         'json_encode error: ' . json_last_error_msg());


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   |no


## Describe your change

refactor detection of `json_encode()` errors

## What problem is this fixing?

As currently written, with an empty body, the client will choose not to json_encode the body. However, if there is a previous `json_last_errror()` from any other json_encode calls during the request lifetime, the client will throw an exception, even though the error is not from _its own_ `json_encode()` call
