### PR TITLE
Include the composer autoloader

### DIFF
--- a/bin/algolia-doctor
+++ b/bin/algolia-doctor
@@ -2,7 +2,12 @@
 <?php
 
 // This kind of sucks.. but we need the composer autoloader, in order to fully check for GuzzleHttp
-include __DIR__ . '/../../../autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    include __DIR__ . '/../../../autoload.php';
+} else {
+    // falback to the local non-composer autoloader which seems to fail to check for Guzzle
+    include __DIR__ . '/../autoload.php';
+}
 
 $doc = new AlgoliaDoctor();
 $doc->checkPhpVersion();

--- a/bin/algolia-doctor
+++ b/bin/algolia-doctor
@@ -1,6 +1,9 @@
 #!/usr/bin/env php
 <?php
 
+// This kind of sucks.. but we need the composer autoloader, in order to fully check for GuzzleHttp
+include __DIR__ . '/../../../autoload.php';
+
 $doc = new AlgoliaDoctor();
 $doc->checkPhpVersion();
 $doc->checkExtensionRequirements();

--- a/bin/algolia-doctor
+++ b/bin/algolia-doctor
@@ -48,7 +48,7 @@ class AlgoliaDoctor
 
     public function checkSerializeParam()
     {
-        if (version_compare(PHP_VERSION, '7.1.0', '>') && '-1' !== ini_get('serialize_precision')) {
+        if (PHP_VERSION_ID > 70100 && '-1' !== ini_get('serialize_precision')) {
             echo '
 When using PHP 7.1+, you must set the "serialize_precision" ini settings to -1.
 See https://github.com/algolia/algoliasearch-client-php/issues/365


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes ... well, sort of... 
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no

## Describe your change

Also include the composer autoloader if available.

## What problem is this fixing?

In order to actually check if the GuzzleClient is available the autoloader should be included. 

As this library might be installed without composer (“¯\_(ツ)_/¯“) it can't be a `require`-call but `include` will work... (sort of)