### PR TITLE
Remove ensureObjectID for Client::multipleBatch

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -168,8 +168,6 @@ class SearchClient
 
     public function multipleBatch($operations, $requestOptions = array())
     {
-        Helpers::ensureObjectID($operations);
-
         $response = $this->api->write(
             'POST',
             api_path('/1/indexes/*/batch'),

--- a/tests/Integration/MultipleIndexTest.php
+++ b/tests/Integration/MultipleIndexTest.php
@@ -30,20 +30,6 @@ class MultipleIndexTest extends AlgoliaIntegrationTestCase
         }
     }
 
-    /**
-     * @expectedException \Algolia\AlgoliaSearch\Exceptions\MissingObjectId
-     */
-    public function testObjectIdIsRequired()
-    {
-        $batch = array_map(function ($item) {
-            unset($item['body']['objectID']);
-
-            return $item;
-        }, $this->getBatch());
-
-        self::getClient()->multipleBatch($batch);
-    }
-
     private function getBatch()
     {
         $batch = array();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

`multipleBatch` should not check for objectIDs in the list of operations. Batch are different forms and don't require an objectID.

## What problem is this fixing?

A batch can be any sort of operations, typically, to delete multiple indexes at once:

```php
$client->multipleBatch([
    [
        'action' => 'delete',
        'indexName' => 'xx',
    ], [
        'action' => 'delete',
        'indexName' => 'yy',
    ]
]);
```
