### PR TITLE
Test against PHP 7.3 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ matrix:
       dist: trusty
       sudo: required
       env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
+    - php: 7.3
+      dist: trusty
+      sudo: required
+    - php: 7.3
+      dist: trusty
+      sudo: required
+      env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
 
     - php: hhvm
       dist: trusty


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

PHP 7.3 will be out on the 6 December, and this Pull Request addresses that.
