### PR TITLE
Introduce NullResponse for empty batches

### DIFF
--- a/src/Response/MultiResponse.php
+++ b/src/Response/MultiResponse.php
@@ -16,6 +16,8 @@ class MultiResponse extends AbstractResponse implements \Iterator, \Countable
         foreach ($this->apiResponse as $response) {
             $response->wait();
         }
+
+        return $this;
     }
 
     public function count()

--- a/src/Response/NullResponse.php
+++ b/src/Response/NullResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+class NullResponse extends AbstractResponse
+{
+    public function __construct()
+    {
+        $this->apiResponse = array();
+    }
+
+    public function wait($requestOptions = array())
+    {
+        return $this;
+    }
+}

--- a/src/Response/NullResponse.php
+++ b/src/Response/NullResponse.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Response;
 
-class NullResponse extends AbstractResponse
+final class NullResponse extends AbstractResponse
 {
     public function __construct()
     {

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -367,6 +367,10 @@ class SearchIndex
             $synonyms = $iteratedOver;
         }
 
+        if (empty($synonyms)) {
+            return new NullResponse();
+        }
+
         Helpers::ensureObjectID($synonyms, 'All synonyms must have an unique objectID to be valid');
 
         $response = $this->api->write(
@@ -474,6 +478,10 @@ class SearchIndex
                 $iteratedOver[] = $r;
             }
             $rules = $iteratedOver;
+        }
+
+        if (empty($rules)) {
+            return new NullResponse();
         }
 
         Helpers::ensureObjectID($rules, 'All rules must have an unique objectID to be valid');

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -65,6 +65,7 @@ class ResponseObjectTest extends NullTestCase
         $c = static::$client;
         $i = $c->initIndex('cool');
 
+        $this->assertInstanceOfResponse($i->saveObjects(array()), 'Algolia\AlgoliaSearch\Response\NullResponse');
         $this->assertInstanceOfResponse($i->saveSynonyms(array()), 'Algolia\AlgoliaSearch\Response\NullResponse');
         $this->assertInstanceOfResponse($i->saveRules(array()), 'Algolia\AlgoliaSearch\Response\NullResponse');
     }

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -60,8 +60,21 @@ class ResponseObjectTest extends NullTestCase
         $this->assertInstanceOfResponse($i->clearRules(array('objectID' => 'test')));
     }
 
-    private function assertInstanceOfResponse($response)
+    public function testNullResponseForEmptyDataset()
     {
+        $c = static::$client;
+        $i = $c->initIndex('cool');
+
+        $this->assertInstanceOfResponse($i->saveSynonyms(array()), 'Algolia\AlgoliaSearch\Response\NullResponse');
+        $this->assertInstanceOfResponse($i->saveRules(array()), 'Algolia\AlgoliaSearch\Response\NullResponse');
+    }
+
+    private function assertInstanceOfResponse($response, $class = '')
+    {
+        if (!$class) {
+            $class = 'Algolia\AlgoliaSearch\Response\AbstractResponse';
+        }
+
         if (is_array($response)) {
             foreach ($response as $r) {
                 $this->assertInstanceOfResponse($r);
@@ -70,7 +83,7 @@ class ResponseObjectTest extends NullTestCase
             return;
         }
 
-        $this->assertInstanceOf('Algolia\AlgoliaSearch\Response\AbstractResponse', $response);
+        $this->assertInstanceOf($class, $response);
         $this->assertTrue(method_exists($response, 'wait'));
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix [this](https://discourse.algolia.com/t/no-content-in-post-request-when-copying-indexes-between-aps/6645)
| Need Doc update   | yes/no


## Describe your change

When sending an empty batch, the API will return a 400 error. This could happen if you passed an empty dataset to the methods or if you were sending exactly 1000, 2000, 3000... objects.

Related to #482 

## What problem is this fixing?

`AccountClient::copyIndex` was breaking because of if you didn't have synonyms or rules, the iterators were empty.

```php
$index1->saveSynonyms($index2->browseSynonyms());
```

## CHANGELOG entry

* If you pass an empty dataset to `saveObjects`, `saveSynonyms` or `saveRules`, you get a NullResponse (waitable) instead of a fatal error.
