### PR TITLE
Always pass Content-Type default header

### DIFF
--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -71,6 +71,7 @@ final class RequestOptionsFactory
                 'X-Algolia-Application-Id' => $this->config->getAppId(),
                 'X-Algolia-API-Key' => $this->config->getApiKey(),
                 'User-Agent' => UserAgent::get(),
+                'Content-Type' => 'application/json',
             ),
             'query' => array(),
             'body' => array(),

--- a/tests/requestOptions.json
+++ b/tests/requestOptions.json
@@ -4,7 +4,8 @@
         {
             "headers": {
                 "X-Algolia-Application-Id": "Algolia-Id",
-                "X-Algolia-API-Key": "Algolia-Key"
+                "X-Algolia-API-Key": "Algolia-Key",
+                "Content-Type": "application/json"
             },
             "body": [],
             "query": [],
@@ -24,6 +25,7 @@
             "headers": {
                 "X-Algolia-Application-Id": "Algolia-Id",
                 "X-Algolia-API-Key": "Algolia-Key",
+                "Content-Type": "application/json",
                 "X-Forwarded-For": "this is an IP",
                 "X-Algolia-UserToken": "User Token for MCM",
                 "X-Forwarded-API-Key": "Another api key to use"
@@ -43,7 +45,8 @@
         {
             "headers": {
                 "X-Algolia-Application-Id": "Algolia-Id",
-                "X-Algolia-API-Key": "Algolia-Key"
+                "X-Algolia-API-Key": "Algolia-Key",
+                "Content-Type": "application/json"
             },
             "body": [],
             "query": {
@@ -70,6 +73,7 @@
             "headers": {
                 "X-Algolia-Application-Id": "Algolia-Id",
                 "X-Algolia-API-Key": "Algolia-Key",
+                "Content-Type": "application/json",
                 "X-Forwarded-API-Key": "Another api key to use"
             },
             "body": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->


## Describe your change

By default, all API calls have `Content-Type: application/json` header. It can be overridden via the default headers pass in the config.

## What problem is this fixing?

The Search API doesn't require it but some other apis do (insight).
