### PR TITLE
[2.1.2] Adds `null` resilience to search $query

### DIFF
--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -10,7 +10,7 @@ use Psr\SimpleCache\CacheInterface;
 
 final class Algolia
 {
-    const VERSION = '2.1.0';
+    const VERSION = '2.1.1';
 
     /**
      * Holds an instance of the simple cache repository (PSR-16).

--- a/src/PlacesClient.php
+++ b/src/PlacesClient.php
@@ -60,6 +60,8 @@ final class PlacesClient
 
     public function search($query, $requestOptions = array())
     {
+        $query = (string) $query;
+
         if (is_array($requestOptions)) {
             $requestOptions['query'] = $query;
         } elseif ($requestOptions instanceof RequestOptions) {

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -259,6 +259,8 @@ class SearchClient
 
     public function searchUserIds($query, $requestOptions = array())
     {
+        $query = (string) $query;
+
         if (is_array($requestOptions)) {
             $requestOptions['query'] = $query;
         } elseif ($requestOptions instanceof RequestOptions) {

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -48,6 +48,8 @@ class SearchIndex
 
     public function search($query, $requestOptions = array())
     {
+        $query = (string) $query;
+
         if (is_array($requestOptions)) {
             $requestOptions['query'] = $query;
         } elseif ($requestOptions instanceof RequestOptions) {
@@ -335,6 +337,8 @@ class SearchIndex
 
     public function searchSynonyms($query, $requestOptions = array())
     {
+        $query = (string) $query;
+
         if (is_array($requestOptions)) {
             $requestOptions['query'] = $query;
         } elseif ($requestOptions instanceof RequestOptions) {
@@ -448,6 +452,8 @@ class SearchIndex
 
     public function searchRules($query, $requestOptions = array())
     {
+        $query = (string) $query;
+
         if (is_array($requestOptions)) {
             $requestOptions['query'] = $query;
         } elseif ($requestOptions instanceof RequestOptions) {

--- a/tests/Unit/RequestTestCase.php
+++ b/tests/Unit/RequestTestCase.php
@@ -29,7 +29,7 @@ abstract class RequestTestCase extends TestCase
     protected function assertBodySubset($subset, RequestInterface $request)
     {
         $body = json_decode((string) $request->getBody(), true);
-        $this->assertArraySubset($subset, $body);
+        $this->assertArraySubset($subset, $body, true);
     }
 
     protected function assertQueryParametersSubset(array $subset, RequestInterface $request)

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Unit;
+
+use Algolia\AlgoliaSearch\Exceptions\RequestException;
+use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\PlacesClient;
+
+class SearchTest extends RequestTestCase
+{
+    public function testQueryAsNullValue()
+    {
+        $client = SearchClient::create('id', 'key');
+
+        try {
+            $client->searchUserIds(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+
+        $index = $client->initIndex('foo');
+
+        try {
+            $index->search(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+
+        try {
+            $index->searchSynonyms(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+
+        try {
+            $index->searchRules(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+
+        try {
+            $index->searchRules(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+
+        $client = PlacesClient::create('id', 'key');
+
+        try {
+            $client->search(null);
+        } catch (RequestException $e) {
+            $this->assertBodySubset(array('query' => '',), $e->getRequest());
+        }
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Need Doc update   | no


## Describe your change

PHP is not a strong typed language, and some developers may enter in the mistake of passing non strings into a `search` method. E.g: In the Laravel Framework:

```php
$query = request('query'); // This may be null.

$results = Post::search($query);
```

This Pull Request addresses this cases, the `null` type is now converted to an empty string.