### PR TITLE
[2.2] Adds restore api key method to search client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Release Notes
 
+## [Unreleased]
+
+### Added
+- `SearchClient::restoreApiKey` method ([#502](https://github.com/algolia/algoliasearch-client-php/pull/502))
+
 ## [v2.1.2](https://github.com/algolia/algoliasearch-client-php/compare/2.1.1...2.1.2)
 
 ### Fixed

--- a/src/Response/RestoreApiKeyResponse.php
+++ b/src/Response/RestoreApiKeyResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Response;
+
+use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
+use Algolia\AlgoliaSearch\Config\SearchConfig;
+use Algolia\AlgoliaSearch\SearchClient;
+
+final class RestoreApiKeyResponse extends AbstractResponse
+{
+    /**
+     * @var \Algolia\AlgoliaSearch\Config\SearchConfig
+     */
+    private $client;
+
+    /**
+     * @var \Algolia\AlgoliaSearch\Config\SearchConfig
+     */
+    private $config;
+
+    /**
+     * @var string API Key to be deleted.
+     */
+    private $key;
+
+    /**
+     * RestoreApiKeyResponse constructor.
+     *
+     * @param array $apiResponse
+     * @param \Algolia\AlgoliaSearch\SearchClient $client
+     * @param \Algolia\AlgoliaSearch\Config\SearchConfig $config
+     * @param string $key
+     */
+    public function __construct(array $apiResponse, SearchClient $client, SearchConfig $config, $key)
+    {
+        $this->apiResponse = $apiResponse;
+        $this->client = $client;
+        $this->config = $config;
+        $this->key = $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($requestOptions = array())
+    {
+        if (! isset($this->client)) {
+            return $this;
+        }
+
+        $retry = 1;
+        $time = $this->config->getWaitTaskTimeBeforeRetry();
+
+        do {
+            try {
+                $this->client->getApiKey($this->key, $requestOptions);
+
+                unset($this->client, $this->config);
+
+                return $this;
+            } catch (NotFoundException $e) {
+                // Try again
+            }
+
+            $retry++;
+            $factor = ceil($retry / 10);
+            usleep($factor * $time); // 0.1 second
+        } while (true);
+    }
+}

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Response\DeleteApiKeyResponse;
 use Algolia\AlgoliaSearch\Response\IndexingResponse;
 use Algolia\AlgoliaSearch\Response\MultipleIndexBatchIndexingResponse;
 use Algolia\AlgoliaSearch\Response\AddApiKeyResponse;
+use Algolia\AlgoliaSearch\Response\RestoreApiKeyResponse;
 use Algolia\AlgoliaSearch\Response\UpdateApiKeyResponse;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
@@ -229,6 +230,13 @@ class SearchClient
         $response = $this->api->write('DELETE', api_path('/1/keys/%s', $key), array(), $requestOptions);
 
         return new DeleteApiKeyResponse($response, $this, $this->config, $key);
+    }
+
+    public function restoreApiKey($key, $requestOptions = array())
+    {
+        $response = $this->api->write('POST', api_path('/1/keys/%s/restore', $key), array(), $requestOptions);
+
+        return new RestoreApiKeyResponse($response, $this, $this->config, $key);
     }
 
     public static function generateSecuredApiKey($parentApiKey, $restrictions)

--- a/tests/Integration/KeysTest.php
+++ b/tests/Integration/KeysTest.php
@@ -49,5 +49,6 @@ class KeysTest extends AlgoliaIntegrationTestCase
 
         $client->restoreApiKey($key['value'])->wait();
         $client->getApiKey($key['value']);
+        $client->deleteApiKey($key['value'])->wait();
     }
 }

--- a/tests/Integration/KeysTest.php
+++ b/tests/Integration/KeysTest.php
@@ -46,5 +46,8 @@ class KeysTest extends AlgoliaIntegrationTestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('Algolia\AlgoliaSearch\Exceptions\NotFoundException', $e);
         }
+
+        $client->restoreApiKey($key['value'])->wait();
+        $client->getApiKey($key['value']);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

This pull request adds the `SearchClient::restoreApiKey` method.