### PR TITLE
Fix autoloader when not using composer

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -16,10 +16,10 @@
 /*
  * Some helper functions are outside classes and need to be loaded
  */
-require_once './src/functions.php';
-require_once './src/Http/Psr7/functions.php';
+require_once __DIR__.'/src/functions.php';
+require_once __DIR__.'/src/Http/Psr7/functions.php';
 
-/**
+/*
  * Based on https://www.php-fig.org/psr/psr-4/examples/.
  */
 spl_autoload_register(function ($class) {
@@ -49,7 +49,6 @@ spl_autoload_register(function ($class) {
         require $file;
     }
 });
-
 
 spl_autoload_register(function ($class) {
     $prefixes = array(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Working on WordPress integration, I realized that in some cases, the required files couldn't be found. I added `__DIR__` to make sure we always require the correct path.
