### PR TITLE
Fix iterator key increment

### DIFF
--- a/src/Iterators/AbstractAlgoliaIterator.php
+++ b/src/Iterators/AbstractAlgoliaIterator.php
@@ -82,6 +82,7 @@ abstract class AbstractAlgoliaIterator implements \Iterator
      */
     public function next()
     {
+        $this->key++;
         $this->batchKey++;
         if ($this->valid()) {
             return;

--- a/tests/Integration/BrowseAndIteratorsTest.php
+++ b/tests/Integration/BrowseAndIteratorsTest.php
@@ -23,7 +23,8 @@ class BrowseAndIteratorsTest extends AlgoliaIntegrationTestCase
 
         $i = 0;
         $total = count($this->airports);
-        foreach ($iterator as $airport) {
+        foreach ($iterator as $key => $airport) {
+            $this->assertEquals($i, $key);
             $i++;
             if ($i > $total) {
                 break;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #514   <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

when browsing an index (objects, rules or synonyms), the "key" (index) of the loop was never incremented.

```php
$iter = $client->initIndex('something')->browseObjects();

foreach ($iter as $key => $value) {
    // without this fix, $key will always be 0
    dump($key);
}
```
