### PR TITLE
Fixes ab test avoiding `Can't delete index under ab testing` error

### DIFF
--- a/tests/Integration/AnalyticsClientTest.php
+++ b/tests/Integration/AnalyticsClientTest.php
@@ -45,5 +45,8 @@ class AnalyticsClientTest extends AlgoliaIntegrationTestCase
 
         $this->assertSame($abTest['name'], 'aaTestName');
         $this->assertSame($abTest['status'], 'active');
+
+        $response = $analyticsClient->deleteABTest($abTest['abTestID']);
+        $searchClient->waitTask(static::$indexes['aa_testing'], $response['taskID']);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

Test suite is not passing. This removes the ab test ensuring that the `tearDown` can remove the index correctly.
