### PR TITLE
Fix sffv function name (plural)

### DIFF
--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -59,7 +59,15 @@ class SearchIndex
         return $this->api->read('POST', api_path('/1/indexes/%s/query', $this->indexName), $requestOptions);
     }
 
+    /**
+     * @deprecated Please use searchForFacetValues instead
+     */
     public function searchForFacetValue($facetName, $facetQuery, $requestOptions = array())
+    {
+        return $this->searchForFacetValues($facetName, $facetQuery, $requestOptions);
+    }
+
+    public function searchForFacetValues($facetName, $facetQuery, $requestOptions = array())
     {
         if (is_array($requestOptions)) {
             $requestOptions['facetQuery'] = $facetQuery;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

I made a mistake when naming the `searchForFacetValues` method in the v2. I forgot the S at the end. The documentation is "correct" (ie use plural method name).

This PR fix the name of the method and is aliasing the wrong name to the correct name.
