### PR TITLE
Add Magento registration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Release Notes
 
 ## [Unreleased]
+### Added
+- Magento registration file was added to allow interceptor creation
 
 ## [v2.2.3](https://github.com/algolia/algoliasearch-client-php/compare/2.2.2...2.2.3)
 

--- a/autoload.php
+++ b/autoload.php
@@ -18,6 +18,7 @@
  */
 require_once __DIR__.'/src/functions.php';
 require_once __DIR__.'/src/Http/Psr7/functions.php';
+require_once __DIR__.'/src/magento_registration.php';
 
 /*
  * Based on https://www.php-fig.org/psr/psr-4/examples/.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         },
         "files": [
             "src/Http/Psr7/functions.php",
-            "src/functions.php"
+            "src/functions.php",
+            "src/magento_registration.php"
         ]
     },
     "autoload-dev": {

--- a/src/magento_registration.php
+++ b/src/magento_registration.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file registers this as a Magento library if the client is running under
+ * Magento 2, enabling code interception (plugins).
+ */
+
+if (class_exists("\Magento\Framework\Component\ComponentRegistrar")) {
+    \Magento\Framework\Component\ComponentRegistrar::register(
+        \Magento\Framework\Component\ComponentRegistrar::LIBRARY,
+        'algolia/algoliasearch-client-php',
+        __DIR__
+    );
+}

--- a/src/magento_registration.php
+++ b/src/magento_registration.php
@@ -3,7 +3,6 @@
  * This file registers this as a Magento library if the client is running under
  * Magento 2, enabling code interception (plugins).
  */
-
 if (class_exists("\Magento\Framework\Component\ComponentRegistrar")) {
     \Magento\Framework\Component\ComponentRegistrar::register(
         \Magento\Framework\Component\ComponentRegistrar::LIBRARY,


### PR DESCRIPTION
Allows the Magento implementation to generate interceptors.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   |no


## Describe your change
A file is added that checks if the library is running under Magento, and if so, it registers the component

## What problem is this fixing?
Without this, it's clunky to create plugins and interceptors in Magento 2.