### PR TITLE
Adding count method to ObjectIterator

### DIFF
--- a/src/Iterators/ObjectIterator.php
+++ b/src/Iterators/ObjectIterator.php
@@ -12,7 +12,7 @@ final class ObjectIterator extends AbstractAlgoliaIterator
     }
 
     /**
-     * Count the number of objects in the iterator
+     * Count the number of objects in the iterator.
      *
      * @return mixed
      */

--- a/src/Iterators/ObjectIterator.php
+++ b/src/Iterators/ObjectIterator.php
@@ -12,6 +12,16 @@ final class ObjectIterator extends AbstractAlgoliaIterator
     }
 
     /**
+     * Count the number of objects in the iterator
+     *
+     * @return mixed
+     */
+    public function count()
+    {
+        return isset($this->response['nbHits']) ? (int) $this->response['nbHits'] : null;
+    }
+
+    /**
      * Exporting objects (records) doesn't use the search function but the
      * browse method, no client-side formatting is required.
      *


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change
Enables counting of the total number of objects in a given index by adding the count method to the OjectIterator. 

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->  

## What problem is this fixing?
Determining the number of objects/records in an index

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
