### PR TITLE
Custom install script escapes space in root path

### DIFF
--- a/bin/install-dependencies-without-composer
+++ b/bin/install-dependencies-without-composer
@@ -6,7 +6,7 @@
 //    true
 //);
 
-$vendorDir = dirname(__DIR__).'/vendor';
+$vendorDir = str_replace(" ", "\\ ", dirname(__DIR__)).'/vendor';
 $dependencies = array(
     'psr/http-message' => 'https://github.com/php-fig/http-message/archive/master.zip',
     'psr/log' => 'https://github.com/php-fig/log/archive/master.zip',


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

If the user has a space in his root path like `/home/julien/My Projects`, the path will be broken in 2 arguments when passed to mkdir for instance.

This PR will escape space to turn the path into `/home/julien/My\ Projects`
