### PR TITLE
Removes memory limit on travis composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - composer install
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install
   - if [ "$LEGACY_HTTP" != "true" ]; then composer require guzzlehttp/guzzle ; fi
 
 before_script:


### PR DESCRIPTION
## What problem is this fixing?

The command `composer install` is causing the following issue on travis in PHP 5.3:
```
$ composer install
You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
Loading composer repositories with package information
Updating dependencies (including require-dev)
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 78 bytes) in phar:///home/travis/.phpenv/versions/5.3.29/bin/composer/src/Composer/DependencyResolver/Solver.php on line 223
PHP Stack trace:
PHP   1. {main}() /home/travis/.phpenv/versions/5.3.29/bin/composer:0
```

This happens on PHP 5.3, because composer has memory issues looking for packages compatible with PHP 5.3. This pull request removes the memory limit.