### PR TITLE
Fix versions not supported for guzzle http client

### DIFF
--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -91,7 +91,7 @@ final class Algolia
     public static function getHttpClient()
     {
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && (\GuzzleHttp\Client::VERSION >= 6 && \GuzzleHttp\Client::VERSION < 7)) {
+            if (class_exists('\GuzzleHttp\Client') && (int) \GuzzleHttp\Client::VERSION[0] === 6) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -37,7 +37,7 @@ final class Algolia
             return false;
         }
 
-        return !self::getCache() instanceof NullCacheDriver;
+        return ! self::getCache() instanceof NullCacheDriver;
     }
 
     /**
@@ -91,7 +91,7 @@ final class Algolia
     public static function getHttpClient()
     {
         if (null === self::$httpClient) {
-            if (\GuzzleHttp\Client::VERSION >= 6) {
+            if (class_exists('\GuzzleHttp\Client') && (\GuzzleHttp\Client::VERSION >= 6 && \GuzzleHttp\Client::VERSION < 7)) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -91,7 +91,7 @@ final class Algolia
     public static function getHttpClient()
     {
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && (int) \GuzzleHttp\Client::VERSION[0] === 6) {
+            if (class_exists('\GuzzleHttp\Client') && 6 === (int) \GuzzleHttp\Client::VERSION[0]) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -91,7 +91,7 @@ final class Algolia
     public static function getHttpClient()
     {
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client')) {
+            if (\GuzzleHttp\Client::VERSION >= 6) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -37,7 +37,7 @@ final class Algolia
             return false;
         }
 
-        return ! self::getCache() instanceof NullCacheDriver;
+        return !self::getCache() instanceof NullCacheDriver;
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no  
| BC breaks?        | no     
| Related Issue     | [#537](https://github.com/algolia/algoliasearch-client-php/issues/537)
| Need Doc update   | no


## Describe your change

This pull request is related to this issue [#537](https://github.com/algolia/algoliasearch-client-php/issues/537)

## What problem is this fixing?

The PHP client has by default implementation for http client. 
However PHP client support guzzle as http client as well. 

A customer can use guzzle but only version 6. If he use a previous version it's not supported. 

In our current implementation, the PHP Client only check if the class exist. If the version is not supported it will automatically wired. Which result to a bug. 

Since the version 4, guzzle use in their 'ClientInterfact' the constant VERSION. I propose to use it to check the version. 


