### PR TITLE
Fix - Enable JSON_UNESCAPED_UNICODE option for request payload encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <Contributors, please add your changes below this line>
 
+* Enable `JSON_UNESCAPED_UNICODE` option on POST/PUT requests payload. 
+
 ### 1.28.0
 
 * Introduce `$client->multipleGetObjects()` to retrieve objects via ObjectID

--- a/src/AlgoliaSearch/Client.php
+++ b/src/AlgoliaSearch/Client.php
@@ -60,6 +60,11 @@ class Client
     protected $curlOptions = array();
 
     /**
+     * @var int
+     */
+    protected $jsonOptions = 0;
+
+    /**
      * @var bool
      */
     protected $placesEnabled = false;
@@ -105,6 +110,11 @@ class Client
                 default:
                     throw new \Exception('Unknown option: '.$option);
             }
+        }
+
+        if (defined('JSON_UNESCAPED_UNICODE')) {
+            // "JSON_UNESCAPED_UNICODE" is introduced in PHP 5.4.0
+            $this->jsonOptions = JSON_UNESCAPED_UNICODE;
         }
 
         $failingHostsCache = isset($options[self::FAILING_HOSTS_CACHE]) ? $options[self::FAILING_HOSTS_CACHE] : null;
@@ -1311,7 +1321,7 @@ class Client
             curl_setopt($curlHandle, CURLOPT_POST, false);
         } else {
             if ($method === 'POST') {
-                $body = ($data) ? Json::encode($data) : '';
+                $body = ($data) ? Json::encode($data, $this->jsonOptions) : '';
                 curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, 'POST');
                 curl_setopt($curlHandle, CURLOPT_POST, true);
                 curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $body);
@@ -1319,7 +1329,7 @@ class Client
                 curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, 'DELETE');
                 curl_setopt($curlHandle, CURLOPT_POST, false);
             } elseif ($method === 'PUT') {
-                $body = ($data) ? Json::encode($data) : '';
+                $body = ($data) ? Json::encode($data, $this->jsonOptions) : '';
                 curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, 'PUT');
                 curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $body);
                 curl_setopt($curlHandle, CURLOPT_POST, true);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #546
| Need Doc update   | no

## Describe your change

Automatically enable `JSON_UNESCAPED_UNICODE` option for request payload encoding.

**I've tested this on a real index an it does work as expected &mdash; the document is indexed perfectly fine**.

