### PR TITLE
Fixes syntax error with old php versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Syntax error in old php versions ([#548](https://github.com/algolia/algoliasearch-client-php/pull/548))
+
 ## [v2.2.5](https://github.com/algolia/algoliasearch-client-php/compare/2.2.4...2.2.5)
 
 ### Fixed

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -91,7 +91,7 @@ final class Algolia
     public static function getHttpClient()
     {
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && 6 === (int) \GuzzleHttp\Client::VERSION[0]) {
+            if (class_exists('\GuzzleHttp\Client') && 6 === (int) substr(\GuzzleHttp\Client::VERSION, 0, 1)) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());


### PR DESCRIPTION
## What problem is this fixing?

With the version `v2.2.3` we have shipped code that doesn't work with old versions of PHP: `Parse error: syntax error, unexpected '[', expecting ',' or ';' `. This pull request addresses that exact same issue.

Fixes #547 .