### PR TITLE
feat(index): add exists method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Release Notes
 
+## [v2.3.0](https://github.com/algolia/algoliasearch-client-php/compare/2.2.6...2.3.0)
+
+### Added
+- `SearchClient::exists` method ([#565](https://github.com/algolia/algoliasearch-client-php/pull/565))
+
 ## [v2.2.6](https://github.com/algolia/algoliasearch-client-php/compare/2.2.5...2.2.6)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Release Notes
 
-## [v2.3.0](https://github.com/algolia/algoliasearch-client-php/compare/2.2.6...2.3.0)
+## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/2.2.6...master)
 
 ### Added
 - `SearchClient::exists` method ([#565](https://github.com/algolia/algoliasearch-client-php/pull/565))

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -14,6 +14,7 @@ use Algolia\AlgoliaSearch\Response\MultiResponse;
 use Algolia\AlgoliaSearch\Response\NullResponse;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\Support\Helpers;
+use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 
 class SearchIndex
 {
@@ -619,6 +620,17 @@ class SearchIndex
         );
 
         return new IndexingResponse($response, $this);
+    }
+
+    public function exists()
+    {
+        try {
+            $this->getSettings();
+        } catch (NotFoundException $exception) {
+            return false;
+        }
+
+        return true;
     }
 
     private function copyTo($tmpIndexName, $requestOptions = array())

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\MissingObjectId;
+use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\Response\BatchIndexingResponse;
 use Algolia\AlgoliaSearch\Response\IndexingResponse;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
@@ -14,7 +15,6 @@ use Algolia\AlgoliaSearch\Response\MultiResponse;
 use Algolia\AlgoliaSearch\Response\NullResponse;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\Support\Helpers;
-use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 
 class SearchIndex
 {

--- a/tests/Integration/ExistsTest.php
+++ b/tests/Integration/ExistsTest.php
@@ -12,7 +12,7 @@ class ExistsTest extends AlgoliaIntegrationTestCase
         static::$indexes['main'] = self::safeName('exists');
     }
 
-    public function testIndexNotExists()
+    public function testIndexNotExist()
     {
         $index = SearchClient::get()->initIndex(static::$indexes['main']);
 

--- a/tests/Integration/ExistsTest.php
+++ b/tests/Integration/ExistsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Integration;
+
+use Algolia\AlgoliaSearch\SearchClient;
+
+class ExistsTest extends AlgoliaIntegrationTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        static::$indexes['main'] = self::safeName('exists');
+    }
+
+    public function testIndexNotExists()
+    {
+        $index = SearchClient::get()->initIndex(static::$indexes['main']);
+
+        self::assertFalse($index->exists());
+    }
+
+    public function testIndexExists()
+    {
+        $index = SearchClient::get()->initIndex(static::$indexes['main']);
+
+        $index
+            ->saveObject(
+                array(
+                    'firstname' => 'Jimmie',
+                ),
+                array('autoGenerateObjectIDIfNotExist' => true)
+            )
+            ->wait();
+
+        self::assertTrue($index->exists());
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #564  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

This adds the `SearchClient::exists` method in the client. It follows the [spec](https://github.com/algolia/algoliasearch-client-specs/blob/master/features/index-exists.md) and [common test suite](https://github.com/algolia/algoliasearch-client-specs/tree/master/common-test-suite#Exists).
