### PR TITLE
Fixes retry strategy when hosts are unreachable

### DIFF
--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Http;
 
+use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\HandlerStack;
@@ -19,17 +20,26 @@ final class Guzzle6HttpClient implements HttpClientInterface
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
     {
+        $e = null;
+
         try {
             $response = $this->client->send($request, array(
                 'timeout' => $timeout,
                 'connect_timeout' => $connectTimeout,
             ));
+
         } catch (GuzzleRequestException $e) {
             if ($e->hasResponse()) {
                 return $e->getResponse();
+            } else {
+                return new Response(
+                    0,
+                    array(),
+                    null,
+                    '1.1',
+                    $e->getMessage()
+                );
             }
-
-            throw $e;
         }
 
         return $response;

--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -20,14 +20,11 @@ final class Guzzle6HttpClient implements HttpClientInterface
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
     {
-        $e = null;
-
         try {
             $response = $this->client->send($request, array(
                 'timeout' => $timeout,
                 'connect_timeout' => $connectTimeout,
             ));
-
         } catch (GuzzleRequestException $e) {
             if ($e->hasResponse()) {
                 return $e->getResponse();

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Http;
 
-use Algolia\AlgoliaSearch\Exceptions\RetriableException;
 use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -103,17 +103,11 @@ final class Php53HttpClient implements HttpClientInterface
         $statusCode = (int) curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
         $responseBody = curl_multi_getcontent($curlHandle);
         $error = curl_error($curlHandle);
+
         $this->releaseMHandle($curlHandle);
         curl_close($curlHandle);
 
-        if (!empty($error)) {
-            throw new RetriableException(
-                'An internal server error occurred on '.$request->getUri()->getHost(),
-                $statusCode
-            );
-        }
-
-        return new Response($statusCode, array(), $responseBody);
+        return new Response($statusCode, array(), $responseBody, '1.1', $error);
     }
 
     private function getMHandle($curlHandle)

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -185,8 +185,10 @@ final class ApiWrapper implements ApiWrapperInterface
         $statusCode = $response->getStatusCode();
 
         if (0 === $statusCode || $statusCode >= 500) {
+            $reason = $response->getReasonPhrase() ?: 'connection problem.';
+
             throw new RetriableException(
-                'An internal server error occurred on '.$request->getUri()->getHost(),
+                'Retriable failure on '.$request->getUri()->getHost().': '.$reason,
                 $statusCode
             );
         }

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -185,7 +185,11 @@ final class ApiWrapper implements ApiWrapperInterface
         $statusCode = $response->getStatusCode();
 
         if (0 === $statusCode || $statusCode >= 500) {
-            $reason = $response->getReasonPhrase() ?: 'connection problem.';
+            $reason = $response->getReasonPhrase();
+
+            if (null === $response->getReasonPhrase() || '' === $response->getReasonPhrase()) {
+                $reason = $statusCode >= 500 ? 'Internal Server Error' : 'Unreachable Host';
+            }
 
             throw new RetriableException(
                 'Retriable failure on '.$request->getUri()->getHost().': '.$reason,

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -6,61 +6,65 @@ use Algolia\AlgoliaSearch\Response\MultiResponse;
 
 class SettingsTest extends AlgoliaIntegrationTestCase
 {
-    private $settings = array(
-        'searchableAttributes' => array('attribute1', 'attribute2', 'attribute3', 'ordered(attribute4)', 'unordered(attribute5)'),
-        'attributesForFaceting' => array('attribute1', 'filterOnly(attribute2)', 'searchable(attribute3)'),
-        'unretrievableAttributes' => array('attribute1', 'attribute2'),
-        'attributesToRetrieve' => array('attribute3', 'attribute4'),
-        'ranking' => array('asc(attribute1)', 'desc(attribute2)', 'attribute', 'custom', 'exact', 'filters', 'geo', 'proximity', 'typo', 'words'),
-        'customRanking' => array('asc(attribute1)', 'desc(attribute1)'),
-        'replicas' => array('main_replica1', 'main_replica2'),
-        'maxValuesPerFacet' => 100,
-        'sortFacetValuesBy' => 'count',
-        'attributesToHighlight' => array('attribute1', 'attribute2'),
-        'attributesToSnippet' => array('attribute1:10', 'attribute2:8'),
-        'highlightPreTag' => '<strong>',
-        'highlightPostTag' => '</strong>',
-        'snippetEllipsisText' => ' and so on.',
-        'restrictHighlightAndSnippetArrays' => true,
-        'hitsPerPage' => 42,
-        'paginationLimitedTo' => 43,
-        'minWordSizefor1Typo' => 2,
-        'minWordSizefor2Typos' => 6,
-        'typoTolerance' => 'false',
-        'allowTyposOnNumericTokens' => false,
-        'ignorePlurals' => true,
-        'disableTypoToleranceOnAttributes' => array('attribute1', 'attribute2'),
-        'disableTypoToleranceOnWords' => array('word1', 'word2'),
-        'separatorsToIndex' => '()array()(',
-        'queryType' => 'prefixNone',
-        'removeWordsIfNoResults' => 'allOptional',
-        'advancedSyntax' => true,
-        'optionalWords' => array('word1', 'word2'),
-        'removeStopWords' => true,
-        'disablePrefixOnAttributes' => array('attribute1', 'attribute2'),
-        'disableExactOnAttributes' => array('attribute1', 'attribute2'),
-        'exactOnSingleWordQuery' => 'word',
-        'enableRules' => false,
-        'numericAttributesForFiltering' => array('attribute1', 'attribute2'),
-        'allowCompressionOfIntegerArray' => true,
-        'attributeForDistinct' => 'attribute1',
-        'distinct' => 2,
-        'replaceSynonymsInHighlight' => false,
-        'minProximity' => 7,
-        'responseFields' => array('hits', 'hitsPerPage'),
-        'maxFacetHits' => 100,
-        'camelCaseAttributes' => array('attribute1', 'attribute2'),
-        'decompoundedAttributes' => array('de' => array('attribute1', 'attribute2'), 'fi' => array('attribute3')),
-        'keepDiacriticsOnCharacters' => 'øé',
-    );
+    private $settings = array();
 
     protected function setUp()
     {
         parent::setUp();
 
-        if (!isset(static::$indexes['main'])) {
+        if (! isset(static::$indexes['main'])) {
+            static::$indexes['main_replica_1'] = self::safeName('settings-mgmt-replica-1');
+            static::$indexes['main_replica_2'] = self::safeName('settings-mgmt-replica-2');
             static::$indexes['main'] = self::safeName('settings-mgmt');
         }
+
+        $this->settings = array(
+            'searchableAttributes' => array('attribute1', 'attribute2', 'attribute3', 'ordered(attribute4)', 'unordered(attribute5)'),
+            'attributesForFaceting' => array('attribute1', 'filterOnly(attribute2)', 'searchable(attribute3)'),
+            'unretrievableAttributes' => array('attribute1', 'attribute2'),
+            'attributesToRetrieve' => array('attribute3', 'attribute4'),
+            'ranking' => array('asc(attribute1)', 'desc(attribute2)', 'attribute', 'custom', 'exact', 'filters', 'geo', 'proximity', 'typo', 'words'),
+            'customRanking' => array('asc(attribute1)', 'desc(attribute1)'),
+            'replicas' => array(static::$indexes['main_replica_1'], static::$indexes['main_replica_2']),
+            'maxValuesPerFacet' => 100,
+            'sortFacetValuesBy' => 'count',
+            'attributesToHighlight' => array('attribute1', 'attribute2'),
+            'attributesToSnippet' => array('attribute1:10', 'attribute2:8'),
+            'highlightPreTag' => '<strong>',
+            'highlightPostTag' => '</strong>',
+            'snippetEllipsisText' => ' and so on.',
+            'restrictHighlightAndSnippetArrays' => true,
+            'hitsPerPage' => 42,
+            'paginationLimitedTo' => 43,
+            'minWordSizefor1Typo' => 2,
+            'minWordSizefor2Typos' => 6,
+            'typoTolerance' => 'false',
+            'allowTyposOnNumericTokens' => false,
+            'ignorePlurals' => true,
+            'disableTypoToleranceOnAttributes' => array('attribute1', 'attribute2'),
+            'disableTypoToleranceOnWords' => array('word1', 'word2'),
+            'separatorsToIndex' => '()array()(',
+            'queryType' => 'prefixNone',
+            'removeWordsIfNoResults' => 'allOptional',
+            'advancedSyntax' => true,
+            'optionalWords' => array('word1', 'word2'),
+            'removeStopWords' => true,
+            'disablePrefixOnAttributes' => array('attribute1', 'attribute2'),
+            'disableExactOnAttributes' => array('attribute1', 'attribute2'),
+            'exactOnSingleWordQuery' => 'word',
+            'enableRules' => false,
+            'numericAttributesForFiltering' => array('attribute1', 'attribute2'),
+            'allowCompressionOfIntegerArray' => true,
+            'attributeForDistinct' => 'attribute1',
+            'distinct' => 2,
+            'replaceSynonymsInHighlight' => false,
+            'minProximity' => 7,
+            'responseFields' => array('hits', 'hitsPerPage'),
+            'maxFacetHits' => 100,
+            'camelCaseAttributes' => array('attribute1', 'attribute2'),
+            'decompoundedAttributes' => array('de' => array('attribute1', 'attribute2'), 'fi' => array('attribute3')),
+            'keepDiacriticsOnCharacters' => 'øé',
+        );
     }
 
     public function testSettings()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #571
| Need Doc update   | no

## What problem is this fixing?

At the moment, both `guzzle`|`legacy` requesters are breaking their contracts/interfaces throwing exceptions from the requesters themselves. As example, the guzzle is throwing a guzzle specific exception `cURL error 7: Failed to connect to XXXXXXXX-dsn.algolia.net port 443: Connection refused` when the host is not available using an exception specific the guzzle.

And this compromises the retry strategy as it doesn't catch exceptions from the requester, and **consequently doesn't retry in other host**.

After this change, both requesters will now always return a response from the requester, when the host is unreachable ( failed to connect, etc ) the status code will be `0`:  indicative that the host is unreachable. The reason how the host is unreachable will be sent on the `$reason` response argument and respectively logged.

If this sounds good for you guys, I will add some tests on this.

**Note**: We may need to re-test the line `$error = curl_error($curlHandle);` on the legacy requester, as it may not work for multi curl implementations.