### PR TITLE
Fix - Unescaped Unicode JSON encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Enable `JSON_UNESCAPED_UNICODE` option for requests bodies JSON encoding. 
+
 ## [v2.2.4](https://github.com/algolia/algoliasearch-client-php/compare/2.2.3...2.2.4)
 
 ### Added

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -42,6 +42,11 @@ final class ApiWrapper implements ApiWrapperInterface
      */
     private $requestOptionsFactory;
 
+    /**
+     * @var int
+     */
+    private $jsonOptions = 0;
+
     public function __construct(
         HttpClientInterface $http,
         AbstractConfig $config,
@@ -52,6 +57,10 @@ final class ApiWrapper implements ApiWrapperInterface
         $this->config = $config;
         $this->clusterHosts = $clusterHosts;
         $this->requestOptionsFactory = $RqstOptsFactory ?: new RequestOptionsFactory($config);
+        if (defined('JSON_UNESCAPED_UNICODE')) {
+            // `JSON_UNESCAPED_UNICODE` is introduced in PHP 5.4.0
+            $this->jsonOptions = JSON_UNESCAPED_UNICODE;
+        }
     }
 
     public function read($method, $path, $requestOptions = array(), $defaultRequestOptions = array())
@@ -228,7 +237,7 @@ final class ApiWrapper implements ApiWrapperInterface
             if (empty($body)) {
                 $body = '';
             } else {
-                $body = \json_encode($body);
+                $body = \json_encode($body, $this->jsonOptions);
                 if (JSON_ERROR_NONE !== json_last_error()) {
                     throw new \InvalidArgumentException(
                         'json_encode error: '.json_last_error_msg());


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #546
| Need Doc update   | no

## Describe your change

Automatically enable `JSON_UNESCAPED_UNICODE` option for request payload encoding.

**I've tested this on a real index an it does work as expected &mdash; the document is indexed perfectly fine**.

This is a port of #545 onto *2.x* master version.
