### PR TITLE
Add reverse geocoding to PlacesClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Release Notes
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/2.4.0...master)
-- `PlacesClient::reverse` method (#589)
+- `PlacesClient::reverse` method ([#589](https://github.com/algolia/algoliasearch-client-php/issues/589))
 
 ## [v2.4.0](https://github.com/algolia/algoliasearch-client-php/compare/2.3.0...2.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Release Notes
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/2.4.0...master)
+- `PlacesClient::reverse` method (#589)
 
 ## [v2.4.0](https://github.com/algolia/algoliasearch-client-php/compare/2.3.0...2.4.0)
 

--- a/src/PlacesClient.php
+++ b/src/PlacesClient.php
@@ -71,6 +71,16 @@ final class PlacesClient
         return $this->api->read('POST', api_path('/1/places/query'), $requestOptions);
     }
 
+    public function reverse($lat, $lng, $requestOptions = array())
+    {
+        if (is_array($requestOptions)) {
+            $requestOptions['aroundLatLng'] = $lat.','.$lng;
+        } elseif ($requestOptions instanceof RequestOptions) {
+            $requestOptions->addBodyParameter('aroundLatLng', $lat.','.$lng);
+        }
+        return $this->api->read('GET', api_path('/1/places/reverse'), $requestOptions);
+    }
+
     public function getObject($objectID, $requestOptions = array())
     {
         return $this->api->read('GET', api_path('/1/places/%s', $objectID), $requestOptions);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #589 
| Need Doc update   | no


## Describe your change

Adds reverse function to PlacesClient to reverse geocoding.

Usage:

     $location = $places->reverse(41.39, 2.07);
