### PR TITLE
Make Logger injectable in ApiWrapper

### DIFF
--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -18,6 +18,7 @@ use Algolia\AlgoliaSearch\Support\Helpers;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 final class ApiWrapper implements ApiWrapperInterface
@@ -42,16 +43,23 @@ final class ApiWrapper implements ApiWrapperInterface
      */
     private $requestOptionsFactory;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
         HttpClientInterface $http,
         AbstractConfig $config,
         ClusterHosts $clusterHosts,
-        RequestOptionsFactory $RqstOptsFactory = null
+        RequestOptionsFactory $RqstOptsFactory = null,
+        LoggerInterface $logger = null
     ) {
         $this->http = $http;
         $this->config = $config;
         $this->clusterHosts = $clusterHosts;
         $this->requestOptionsFactory = $RqstOptsFactory ?: new RequestOptionsFactory($config);
+        $this->logger = $logger ?: Algolia::getLogger();
     }
 
     public function read($method, $path, $requestOptions = array(), $defaultRequestOptions = array())
@@ -252,6 +260,6 @@ final class ApiWrapper implements ApiWrapperInterface
      */
     private function log($level, $message, array $context = array())
     {
-        Algolia::getLogger()->log($level, 'Algolia API client: '.$message, $context);
+        $this->logger->log($level, 'Algolia API client: '.$message, $context);
     }
 }

--- a/tests/Integration/IndexManagementTest.php
+++ b/tests/Integration/IndexManagementTest.php
@@ -54,7 +54,7 @@ class IndexManagementTest extends AlgoliaIntegrationTestCase
         $this->assertArraySubset($settings, $set);
 
         static::$indexes['copy-scoped'] = $copyIndexName.'-scoped-settings';
-        $client->copyIndex(static::$indexes['main'], static::$indexes['copy-scoped'], array('scope' => 'settings'));
+        $client->copyIndex(static::$indexes['main'], static::$indexes['copy-scoped'], array('scope' => array('settings')));
         $this->assertIndexExists(static::$indexes['copy-scoped']);
         $res = $client->initIndex(static::$indexes['copy-scoped'])->search('');
         $this->assertEquals(0, $res['nbHits']);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #592   <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Today, the logger is only used in ApiWrapper and is not injectable. It's the only class used that you can't inject. This PR makes it injectable.

If you don't inject it, we'll keep calling `Algolia::getLogger()`.
