### PR TITLE
Move ClusterHosts instantiation logic from SearchClient to ClusterHosts

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -54,22 +54,10 @@ class SearchClient
     {
         $config = clone $config;
 
-        $cacheKey = sprintf('%s-clusterHosts-%s', __CLASS__, $config->getAppId());
-
-        if ($hosts = $config->getHosts()) {
-            // If a list of hosts was passed, we ignore the cache
-            $clusterHosts = ClusterHosts::create($hosts);
-        } elseif (false === ($clusterHosts = ClusterHosts::createFromCache($cacheKey))) {
-            // We'll try to restore the ClusterHost from cache, if we cannot
-            // we create a new instance and set the cache key
-            $clusterHosts = ClusterHosts::createFromAppId($config->getAppId())
-                ->setCacheKey($cacheKey);
-        }
-
         $apiWrapper = new ApiWrapper(
             Algolia::getHttpClient(),
             $config,
-            $clusterHosts
+            ClusterHosts::createFromSearchConfig($config)
         );
 
         return new static($apiWrapper, $config);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | https://github.com/algolia/search-bundle/issues/317
| Need Doc update   | no

## Describe your change

Moved logic for ClusterHosts instantiation to correct place. Will slim down logic in ApiWrapper and thus more easily reuse it in DI. Will aid with https://github.com/algolia/search-bundle/issues/317

## What problem is this fixing?

When injectin ApiWrapper into SearchClient manually, user has to replicate ClusterHosts logic in DI configuration. Extracting this logic will allow to reuse it when defining ApiWrapper service.
