### PR TITLE
fix: rules with empty params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/2.5.0...master)
 
+### Fixed
+- Serialization issue on `saveRule` and `saveRules` when rule contains an empty list of consequence params ([#606](https://github.com/algolia/algoliasearch-client-php/pull/606))
+
 ## [v2.5.0](https://github.com/algolia/algoliasearch-client-php/compare/2.4.0...2.5.0)
 
 ### Added

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -513,6 +513,18 @@ class SearchIndex
 
         Helpers::ensureObjectID($rules, 'All rules must have an unique objectID to be valid');
 
+        /**
+         * If consequence `params` is an array without keys, we are going to remove it
+         * from the payload of the rule. Otherwise the transporter layer will serialize
+         * `params` to an empty array [] instead of an empty object {} making an invalid
+         * rule on the engine side.
+         */
+        foreach ($rules as $key => $rule) {
+            if (isset($rule['consequence']) && empty($rule['consequence']['params'])) {
+                unset($rules[$key]['consequence']['params']);
+            }
+        }
+
         $response = $this->api->write(
             'POST',
             api_path('/1/indexes/%s/rules/batch', $this->indexName),

--- a/tests/Integration/RulesTest.php
+++ b/tests/Integration/RulesTest.php
@@ -8,7 +8,7 @@ class RulesTest extends AlgoliaIntegrationTestCase
     {
         parent::setUp();
 
-        if (!isset(static::$indexes['main'])) {
+        if (! isset(static::$indexes['main'])) {
             static::$indexes['main'] = self::safeName('rules-mgmt');
         }
     }
@@ -69,6 +69,49 @@ class RulesTest extends AlgoliaIntegrationTestCase
 
         $this->assertEquals(3, $i);
     }
+
+    public function testSerializationOfConsequenceParams()
+    {
+        /** @var \Algolia\AlgoliaSearch\SearchIndex $index */
+        $index = static::getClient()->initIndex(static::$indexes['main']);
+
+        $rule = array(
+            'objectID' => 'rule-without-consequence-params',
+            'consequence' => array(
+                // 'params' => array(),
+                'hide' => array(array('objectID' => 'myID1')),
+            ),
+        );
+
+        $index->saveRule($rule)->wait();
+        self::assertEquals($rule, $index->getRule('rule-without-consequence-params'));
+
+        $rule = array(
+            'objectID' => 'rule-with-empty-consequence-params',
+            'consequence' => array(
+                'params' => array(),
+                'hide' => array(array('objectID' => 'myID1')),
+            ),
+        );
+
+        $index->saveRule($rule)->wait();
+        unset($rule['consequence']['params']);
+        self::assertEquals($rule, $index->getRule('rule-with-empty-consequence-params'));
+
+        $rule = array(
+            'objectID' => 'rule-with-consequence-params',
+            'consequence' => array(
+                'params' => array(
+                    'filters' => 'category = 1'
+                ),
+                'hide' => array(array('objectID' => 'myID1')),
+            ),
+        );
+
+        $index->saveRule($rule)->wait();
+        self::assertEquals($rule, $index->getRule('rule-with-consequence-params'));
+    }
+
 
     private function getRuleStub($objectID = 'my-rule')
     {

--- a/tests/Integration/RulesTest.php
+++ b/tests/Integration/RulesTest.php
@@ -95,6 +95,7 @@ class RulesTest extends AlgoliaIntegrationTestCase
         );
 
         $index->saveRule($rule)->wait();
+        // saveRule should unset params because is an empty list.
         unset($rule['consequence']['params']);
         self::assertEquals($rule, $index->getRule('rule-with-empty-consequence-params'));
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no

## Describe your change

This pull request fixes an issue when people get rules with empty list of consequence params from `getRule` or `browseRules` and then save them with a `saveRule` or `saveRules`.