### PR TITLE
chore(insights): send_events tests

### DIFF
--- a/tests/Integration/InsightsClientTest.php
+++ b/tests/Integration/InsightsClientTest.php
@@ -3,10 +3,16 @@
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\InsightsClient;
-use PHPUnit\Framework\TestCase;
+use Algolia\AlgoliaSearch\SearchClient;
 
-class InsightsClientTest extends TestCase
+class InsightsClientTest extends AlgoliaIntegrationTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+        static::$indexes['insights'] = self::safeName('insights');
+    }
+
     public function testUserInsights()
     {
         $u = InsightsClient::create()->user('userTokenForTest');
@@ -37,6 +43,52 @@ class InsightsClientTest extends TestCase
         $this->assertEvent(
             $u->viewedObjectIDs('eventName', 'indexName', 'objectIDs')
         );
+    }
+
+    public function testSendEvent()
+    {
+        $two_days_ago_ms = (time() - (2 * 24 * 60 * 60)) * 1000;
+        $insightClient = InsightsClient::create();
+        $searchClient = SearchClient::create();
+        $searchClient->initIndex(static::$indexes['insights'])->delete()->wait();
+        $searchClient->initIndex(static::$indexes['insights'])->saveObject(array(
+            'objectID' => 1,
+        ))->wait();
+
+        $response = $insightClient->sendEvent(array(
+                'eventType' => 'click',
+                'eventName' => 'foo',
+                'index' => static::$indexes['insights'],
+                'userToken' => 'bar',
+                'objectIDs' => array('one', 'two'),
+                'timestamp' => $two_days_ago_ms,
+            )
+        );
+
+        $this->assertArraySubset(array('status' => 200), $response);
+    }
+
+    public function testSendEvents()
+    {
+        $two_days_ago_ms = (time() - (2 * 24 * 60 * 60)) * 1000;
+        $insightClient = InsightsClient::create();
+        $searchClient = SearchClient::create();
+        $searchClient->initIndex(static::$indexes['insights'])->delete()->wait();
+        $searchClient->initIndex(static::$indexes['insights'])->saveObject(array(
+            'objectID' => 1,
+        ))->wait();
+
+        $response = $insightClient->sendEvents(array(array(
+                'eventType' => 'click',
+                'eventName' => 'foo',
+                'index' => static::$indexes['insights'],
+                'userToken' => 'bar',
+                'objectIDs' => array('one', 'two'),
+                'timestamp' => $two_days_ago_ms,
+            ))
+        );
+
+        $this->assertArraySubset(array('status' => 200), $response);
     }
 
     private function assertEvent($response)

--- a/tests/Integration/InsightsClientTest.php
+++ b/tests/Integration/InsightsClientTest.php
@@ -47,52 +47,53 @@ class InsightsClientTest extends AlgoliaIntegrationTestCase
 
     public function testSendEvent()
     {
-        $two_days_ago_ms = (time() - (2 * 24 * 60 * 60)) * 1000;
-        $insightClient = InsightsClient::create();
+        $twoDaysAgoMs = (time() - (2 * 24 * 60 * 60)) * 1000;
+        $insightsClient = InsightsClient::create();
         $searchClient = SearchClient::create();
-        $searchClient->initIndex(static::$indexes['insights'])->delete()->wait();
         $searchClient->initIndex(static::$indexes['insights'])->saveObject(array(
             'objectID' => 1,
         ))->wait();
 
-        $response = $insightClient->sendEvent(array(
+        $response = $insightsClient->sendEvent(array(
                 'eventType' => 'click',
                 'eventName' => 'foo',
                 'index' => static::$indexes['insights'],
                 'userToken' => 'bar',
                 'objectIDs' => array('one', 'two'),
-                'timestamp' => $two_days_ago_ms,
+                'timestamp' => $twoDaysAgoMs,
             )
         );
 
-        $this->assertArraySubset(array('status' => 200), $response);
+        $this->assertEvent($response);
     }
 
     public function testSendEvents()
     {
-        $two_days_ago_ms = (time() - (2 * 24 * 60 * 60)) * 1000;
-        $insightClient = InsightsClient::create();
+        $twoDaysAgoMs = (time() - (2 * 24 * 60 * 60)) * 1000;
+        $insightsClient = InsightsClient::create();
         $searchClient = SearchClient::create();
-        $searchClient->initIndex(static::$indexes['insights'])->delete()->wait();
         $searchClient->initIndex(static::$indexes['insights'])->saveObject(array(
             'objectID' => 1,
         ))->wait();
 
-        $response = $insightClient->sendEvents(array(array(
+        $response = $insightsClient->sendEvents(array(array(
                 'eventType' => 'click',
                 'eventName' => 'foo',
                 'index' => static::$indexes['insights'],
                 'userToken' => 'bar',
                 'objectIDs' => array('one', 'two'),
-                'timestamp' => $two_days_ago_ms,
+                'timestamp' => $twoDaysAgoMs,
             ))
         );
 
-        $this->assertArraySubset(array('status' => 200), $response);
+        $this->assertEvent($response);
     }
 
     private function assertEvent($response)
     {
-        $this->assertArraySubset(array('status' => 200), $response);
+        $this->assertArraySubset(array(
+            'message' => 'OK',
+            'status' => 200,
+        ), $response);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #569 
| Need Doc update   | no


## Describe your change

Adds tests for `send_events`/`send_event` and add the timestamp option
