### PR TITLE
Fix - Unescaped Unicode JSON encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ before_script:
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then eval $(./algolia-keys export) && php vendor/bin/phpunit -v --testsuite Unit,Definition,Community; else php vendor/bin/phpunit -v; fi
-  - vendor/bin/o-fixer fix -v --dry-run
+  - vendor/bin/php-cs-fixer fix -v --dry-run
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then php tests/tests-no-composer.php; else echo 'Skipped'; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,5 +73,5 @@ before_script:
 script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then eval $(./algolia-keys export) && php vendor/bin/phpunit -v --testsuite Unit,Definition,Community; else php vendor/bin/phpunit -v; fi
   - vendor/bin/php-cs-fixer fix -v --dry-run
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then php tests/tests-no-composer.php; else echo 'Skipped'; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then eval $(./algolia-keys export) && php tests/tests-no-composer.php; else echo 'Skipped'; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ before_script:
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then eval $(./algolia-keys export) && php vendor/bin/phpunit -v --testsuite Unit,Definition,Community; else php vendor/bin/phpunit -v; fi
-  - vendor/bin/php-cs-fixer fix -v --dry-run
-  - php tests/tests-no-composer.php
+  - vendor/bin/o-fixer fix -v --dry-run
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then php tests/tests-no-composer.php; else echo 'Skipped'; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/2.7.0...master)
 
+### Added
+- Enable `JSON_UNESCAPED_UNICODE` option for requests bodies JSON encoding. 
+
 ## [v2.7.0](https://github.com/algolia/algoliasearch-client-php/compare/2.6.2...2.7.0)
 
 ### Added

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -48,6 +48,11 @@ final class ApiWrapper implements ApiWrapperInterface
      */
     private $logger;
 
+    /**
+     * @var int
+     */
+    private $jsonOptions = 0;
+
     public function __construct(
         HttpClientInterface $http,
         AbstractConfig $config,
@@ -60,6 +65,10 @@ final class ApiWrapper implements ApiWrapperInterface
         $this->clusterHosts = $clusterHosts;
         $this->requestOptionsFactory = $RqstOptsFactory ?: new RequestOptionsFactory($config);
         $this->logger = $logger ?: Algolia::getLogger();
+        if (defined('JSON_UNESCAPED_UNICODE')) {
+            // `JSON_UNESCAPED_UNICODE` is introduced in PHP 5.4.0
+            $this->jsonOptions = JSON_UNESCAPED_UNICODE;
+        }
     }
 
     public function read($method, $path, $requestOptions = array(), $defaultRequestOptions = array())
@@ -239,7 +248,7 @@ final class ApiWrapper implements ApiWrapperInterface
             if (empty($body)) {
                 $body = '';
             } else {
-                $body = \json_encode($body);
+                $body = \json_encode($body, $this->jsonOptions);
                 if (JSON_ERROR_NONE !== json_last_error()) {
                     throw new \InvalidArgumentException('json_encode error: '.json_last_error_msg());
                 }

--- a/tests/Unit/ApiWrapperTest.php
+++ b/tests/Unit/ApiWrapperTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests\Unit;
+
+use Algolia\AlgoliaSearch\Config\SearchConfig;
+use Algolia\AlgoliaSearch\Http\HttpClientInterface;
+use Algolia\AlgoliaSearch\Http\Psr7\Response;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use Psr\Http\Message\RequestInterface;
+
+class ApiWrapperTest extends TestCase
+{
+    const UNICODE_STRING = 'Я дивився на шторм – неймовірно красивий і жахаючий.';
+    const EXPECTED_JSON = '{"data":"Я дивився на шторм – неймовірно красивий і жахаючий."}';
+    const EXPECTED_JSON_PRE_PHP_5_4 = '{"data":"\u042f \u0434\u0438\u0432\u0438\u0432\u0441\u044f \u043d\u0430 \u0448\u0442\u043e\u0440\u043c \u2013 \u043d\u0435\u0439\u043c\u043e\u0432\u0456\u0440\u043d\u043e \u043a\u0440\u0430\u0441\u0438\u0432\u0438\u0439 \u0456 \u0436\u0430\u0445\u0430\u044e\u0447\u0438\u0439."}';
+
+    /**
+     * @see https://github.com/algolia/algoliasearch-client-php/issues/546
+     */
+    public function testUnescapedJsonEncoding()
+    {
+        /** @var HttpClientInterface $http */
+        $http = $this->mock(
+            '\Algolia\AlgoliaSearch\Http\HttpClientInterface',
+            function (PHPUnit_Framework_MockObject_MockObject $mock) {
+                $mock->expects(TestCase::once())->method('sendRequest')
+                    ->willReturnCallback(function (RequestInterface $request) {
+                        ApiWrapperTest::assertRequestJson($request);
+
+                        return new Response(200, array(), '{}');
+                    });
+            }
+        );
+
+        $api = new ApiWrapper($http, SearchConfig::create(), ClusterHosts::create('127.0.0.1'));
+
+        $api->write('post', '/', array('data' => self::UNICODE_STRING));
+    }
+
+    private function mock($class, callable $configure = null)
+    {
+        $mock = $this->getMock($class);
+        if ($configure) {
+            $configure($mock);
+        }
+
+        return $mock;
+    }
+
+    private static function assertRequestJson(RequestInterface $request)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
+            TestCase::assertEquals(
+                ApiWrapperTest::EXPECTED_JSON_PRE_PHP_5_4,
+                $request->getBody()->getContents()
+            );
+
+            return;
+        }
+
+        TestCase::assertEquals(
+            ApiWrapperTest::EXPECTED_JSON,
+            $request->getBody()->getContents()
+        );
+    }
+}

--- a/tests/Unit/ApiWrapperTest.php
+++ b/tests/Unit/ApiWrapperTest.php
@@ -45,8 +45,6 @@ class ApiWrapperTest extends TestCase implements HttpClientInterface
     /**
      * This test-case implements HttpClientInterface
      * in order to assert request body.
-     *
-     * @inheritDoc
      */
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
     {

--- a/tests/Unit/ApiWrapperTest.php
+++ b/tests/Unit/ApiWrapperTest.php
@@ -8,62 +8,50 @@ use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Psr\Http\Message\RequestInterface;
 
-class ApiWrapperTest extends TestCase
+class ApiWrapperTest extends TestCase implements HttpClientInterface
 {
     const UNICODE_STRING = 'Я дивився на шторм – неймовірно красивий і жахаючий.';
     const EXPECTED_JSON = '{"data":"Я дивився на шторм – неймовірно красивий і жахаючий."}';
     const EXPECTED_JSON_PRE_PHP_5_4 = '{"data":"\u042f \u0434\u0438\u0432\u0438\u0432\u0441\u044f \u043d\u0430 \u0448\u0442\u043e\u0440\u043c \u2013 \u043d\u0435\u0439\u043c\u043e\u0432\u0456\u0440\u043d\u043e \u043a\u0440\u0430\u0441\u0438\u0432\u0438\u0439 \u0456 \u0436\u0430\u0445\u0430\u044e\u0447\u0438\u0439."}';
 
     /**
+     * @var RequestInterface[]
+     */
+    private $recordedRequests = array();
+
+    /**
      * @see https://github.com/algolia/algoliasearch-client-php/issues/546
      */
     public function testUnescapedJsonEncoding()
     {
-        /** @var HttpClientInterface $http */
-        $http = $this->mock(
-            '\Algolia\AlgoliaSearch\Http\HttpClientInterface',
-            function (PHPUnit_Framework_MockObject_MockObject $mock) {
-                $mock->expects(TestCase::once())->method('sendRequest')
-                    ->willReturnCallback(function (RequestInterface $request) {
-                        ApiWrapperTest::assertRequestJson($request);
-
-                        return new Response(200, array(), '{}');
-                    });
-            }
-        );
-
-        $api = new ApiWrapper($http, SearchConfig::create(), ClusterHosts::create('127.0.0.1'));
+        $api = new ApiWrapper($this, SearchConfig::create(), ClusterHosts::create('127.0.0.1'));
 
         $api->write('post', '/', array('data' => self::UNICODE_STRING));
+
+        $this->assertCount(1, $this->recordedRequests);
+
+        foreach ($this->recordedRequests as $request) {
+            $contents = $request->getBody()->getContents();
+            if (version_compare(PHP_VERSION, '5.4.0') < 0) {
+                $this->assertEquals(ApiWrapperTest::EXPECTED_JSON_PRE_PHP_5_4, $contents);
+                continue;
+            }
+            $this->assertEquals(ApiWrapperTest::EXPECTED_JSON, $contents);
+        }
     }
 
-    private function mock($class, callable $configure = null)
+    /**
+     * This test-case implements HttpClientInterface
+     * in order to assert request body.
+     *
+     * @inheritDoc
+     */
+    public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
     {
-        $mock = $this->getMock($class);
-        if ($configure) {
-            $configure($mock);
-        }
+        $this->recordedRequests[] = $request;
 
-        return $mock;
-    }
-
-    private static function assertRequestJson(RequestInterface $request)
-    {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            TestCase::assertEquals(
-                ApiWrapperTest::EXPECTED_JSON_PRE_PHP_5_4,
-                $request->getBody()->getContents()
-            );
-
-            return;
-        }
-
-        TestCase::assertEquals(
-            ApiWrapperTest::EXPECTED_JSON,
-            $request->getBody()->getContents()
-        );
+        return new Response(200, array(), '{}');
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #546
| Need Doc update   | no

## Describe your change

Automatically enable `JSON_UNESCAPED_UNICODE` option for request payload encoding.

**I've tested this on a real index an it does work as expected &mdash; the document is indexed perfectly fine**.

This is a port of #545 onto *2.x* master version. 
Reincarnation of #577 with a unit test added.
