### PR TITLE
fix(mcm): getTopUserId method

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -296,7 +296,7 @@ class SearchClient
 
     public function getTopUserId($requestOptions = array())
     {
-        return $this->api->read('GET', api_path('/1/clusters/mapping/%top'), $requestOptions);
+        return $this->api->read('GET', api_path('/1/clusters/mapping/top'), $requestOptions);
     }
 
     public function assignUserId($userId, $clusterName, $requestOptions = array())


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #609
| Need Doc update   | no


## Describe your change

There was an error in the path used for the `getTopUserId` method