### PR TITLE
fix(auto-generate-id-message): improves wording

### DIFF
--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -186,7 +186,7 @@ class SearchIndex
             $message .= "If your batch has a unique identifier but isn't called objectID,\n";
             $message .= "you can map it automatically using `saveObjects(\$objects, ['objectIDKey' => 'primary'])`\n\n";
             $message .= "Algolia is also able to generate objectIDs automatically but *it's not recommended*.\n";
-            $message .= "To do it, use `saveObjects(\$objects, ['autoGenerateObjectIDIfNotExist' => true])`\n\n";
+            $message .= "To do it, use `['autoGenerateObjectIDIfNotExist' => true] on the request options parameter`\n\n";
 
             throw new MissingObjectId($message);
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #604 
| Need Doc update   | no


## Describe your change

Fix the error message on the `saveObjects` method