### PR TITLE
fix(get-top-user-ids): rename getTopUserId to getTopUserIds

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -302,7 +302,22 @@ class SearchClient
         return $this->api->read('GET', api_path('/1/clusters/mapping/%s', $userId), $requestOptions);
     }
 
+    /**
+     * @deprecated since 2.6.1, use getTopUserIds instead.
+     */
     public function getTopUserId($requestOptions = array())
+    {
+        return $this->getTopUserIds($requestOptions);
+    }
+
+    /**
+     * Get the top 10 userIDs with the highest number of records per cluster.
+     *
+     * @param array $requestOptions
+     *
+     * @return array<string, mixed>
+     */
+    public function getTopUserIds($requestOptions = array())
     {
         return $this->api->read('GET', api_path('/1/clusters/mapping/top'), $requestOptions);
     }
@@ -329,8 +344,8 @@ class SearchClient
      * Assign multiple userIds to the given cluster name.
      *
      * @param array<int, int> $userIds
-     * @param string          $clusterName    [description]
-     * @param array           $requestOptions [description]
+     * @param string          $clusterName
+     * @param array           $requestOptions
      *
      * @return array<string, mixed>
      */

--- a/tests/Integration/MultiClusterManagementTest.php
+++ b/tests/Integration/MultiClusterManagementTest.php
@@ -91,6 +91,12 @@ class MultiClusterManagementTest extends AlgoliaIntegrationTestCase
         $this->assertArrayHasKey('nbRecords', $topUser);
         $this->assertArrayHasKey('dataSize', $topUser);
 
+        $response = $this->mcmClient->getTopUserIds();
+        $topUser = $response['topUsers'][$clusterName][0];
+        $this->assertArrayHasKey('userID', $topUser);
+        $this->assertArrayHasKey('nbRecords', $topUser);
+        $this->assertArrayHasKey('dataSize', $topUser);
+
         $response = $this->autoRetryRemoveUserId($this->mcmUserId0);
         $this->assertArrayHasKey('deletedAt', $response);
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #615 
| Need Doc update   | yes


## Describe your change
This PR renames the `getTopUserId` to `getTopUserIds`. Please keep in mind that `2.6.1` is used in annotations, make sure we update this to the right version number if necessary.