### PR TITLE
fix(deserialization-of-continue-100): forces expect header to be false

### DIFF
--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -15,7 +15,9 @@ final class Guzzle6HttpClient implements HttpClientInterface
 
     public function __construct(GuzzleClient $client = null)
     {
-        $this->client = $client ?: static::buildClient();
+        $this->client = $client ?: static::buildClient(array(
+            'expect' => false,
+        ));
     }
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)

--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -15,9 +15,7 @@ final class Guzzle6HttpClient implements HttpClientInterface
 
     public function __construct(GuzzleClient $client = null)
     {
-        $this->client = $client ?: static::buildClient(array(
-            'expect' => false,
-        ));
+        $this->client = $client ?: static::buildClient();
     }
 
     public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -192,7 +192,7 @@ final class ApiWrapper implements ApiWrapperInterface
         $body = (string) $response->getBody();
         $statusCode = $response->getStatusCode();
 
-        if (0 === $statusCode || $statusCode >= 500) {
+        if (0 === $statusCode || ($statusCode >= 100 && $statusCode < 200) || $statusCode >= 500) {
             $reason = $response->getReasonPhrase();
 
             if (null === $response->getReasonPhrase() || '' === $response->getReasonPhrase()) {


### PR DESCRIPTION
This pull request fixes the fact that the range 1xx wasn't considered retryable.