### PR TITLE
Add PSR-18 HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "friendsofphp/php-cs-fixer": "^2.0",
         "fzaninotto/faker": "^1.8",
         "phpunit/phpunit": "^4.8",
+        "psr/http-client": "^1.0",
         "symfony/yaml": "^2.0 || ^4.0"
     },
     "autoload": {

--- a/src/Http/Psr18HttpClient.php
+++ b/src/Http/Psr18HttpClient.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Http;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+
+class Psr18HttpClient implements HttpClientInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(ClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
+    {
+        return $this->httpClient->sendRequest($request);
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fixes #619
| Need Doc update   | no


Currently there are only raw curl or Guzzle 6 adapters, while ecosystem is moving to abstractions. This can be seen with Guzzle 7 which fully implements PSR-18, or new Symfony HTTP client shipping PSR-18 adapter. Pretty much every PHP HTTP client takes care about PSR-18. We are ourselves not using Guzzle directly anymore, but through HttPlug. Hence we had to create such adapter ourselves in our project.

Moving forward, I would suggest to require PSR Http client in Algolia directly and deprecate current adapters, instead of having `Algolia\AlgoliaSearch\Http\HttpClientInterface`. Only difference it has is unnecessary $timeout and $connectTimeout parameters. In my opinion these should be configured inside wrapped http client, not overridden via your adapters.