### PR TITLE
chore(http): add support of guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,33 @@ matrix:
     - php: 7.2
       dist: bionic
       sudo: required
-      env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
+      env: GUZZLE_6=true # Run the CTS against Guzzle 6
+    - php: 7.2
+      dist: bionic
+      sudo: required
+      env: GUZZLE_7=true # Run the CTS against Guzzle 7
     - php: 7.3
       dist: bionic
       sudo: required
     - php: 7.3
       dist: bionic
       sudo: required
-      env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
+      env: GUZZLE_6=true # Run the CTS against Guzzle 6
+    - php: 7.3
+      dist: bionic
+      sudo: required
+      env: GUZZLE_7=true # Run the CTS against Guzzle 7
     - php: 7.4
       dist: bionic
       sudo: required
     - php: 7.4
       dist: bionic
       sudo: required
-      env: LEGACY_HTTP=true # Don't install Guzzle to test PHP53HttpClient
+      env: GUZZLE_6=true # Run the CTS against Guzzle 6
+    - php: 7.4
+      dist: bionic
+      sudo: required
+      env: GUZZLE_7=true # Run the CTS against Guzzle 7
 
     - php: hhvm
       dist: trusty
@@ -52,7 +64,8 @@ cache:
 
 install:
   - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install
-  - if [ "$LEGACY_HTTP" != "true" ]; then composer require guzzlehttp/guzzle ; fi
+  - if [ $GUZZLE_6 == "true" ]; then composer require guzzlehttp/guzzle:^6.5 ; fi
+  - if [ $GUZZLE_7 == "true" ]; then composer require guzzlehttp/guzzle:~7 ; fi
 
 before_script:
   - wget https://alg.li/algolia-keys && chmod +x algolia-keys

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -86,8 +86,17 @@ final class Algolia
 
     public static function getHttpClient()
     {
+        $guzzleVersion = null;
+        if (interface_exists('\GuzzleHttp\ClientInterface')) {
+            if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+                $guzzleVersion = (int) substr(\GuzzleHttp\Client::VERSION, 0, 1);
+            } else {
+                $guzzleVersion = \GuzzleHttp\ClientInterface::MAJOR_VERSION;
+            }
+        }
+
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && 6 === (int) substr(\GuzzleHttp\Client::VERSION, 0, 1)) {
+            if (class_exists('\GuzzleHttp\Client') && 6 <= $guzzleVersion) {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());

--- a/src/Support/UserAgent.php
+++ b/src/Support/UserAgent.php
@@ -47,7 +47,11 @@ final class UserAgent
             $segments['HHVM'] = HHVM_VERSION;
         }
         if (interface_exists('\GuzzleHttp\ClientInterface')) {
-            $segments['Guzzle'] = \GuzzleHttp\ClientInterface::VERSION;
+            if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+                $segments['Guzzle'] = \GuzzleHttp\ClientInterface::VERSION;
+            } else {
+                $segments['Guzzle'] = \GuzzleHttp\ClientInterface::MAJOR_VERSION;
+            }
         }
 
         return $segments;

--- a/tests/Unit/UserAgentTest.php
+++ b/tests/Unit/UserAgentTest.php
@@ -18,7 +18,11 @@ class UserAgentTest extends TestCase
             $this->default .= '; HHVM ('.HHVM_VERSION.')';
         }
         if (interface_exists('\GuzzleHttp\ClientInterface')) {
-            $this->default .= '; Guzzle ('.\GuzzleHttp\ClientInterface::VERSION.')';
+            if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+                $this->default .= '; Guzzle ('.\GuzzleHttp\ClientInterface::VERSION.')';
+            } else {
+                $this->default .= '; Guzzle ('.\GuzzleHttp\ClientInterface::MAJOR_VERSION.')';
+            }
         }
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #619
| Need Doc update   | no


## Describe your change

Adds support for Guzzle 7, main difference being how to retrieve the guzzle version for tagging user-agent and choosing adapter. Otherwise the behaviour of the current guzzle adapter works with Guzzle 7.