### PR TITLE
Checks if apikey or appid exist in config array and throws exception …

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -56,7 +56,7 @@ class SearchClient
         $config = clone $config;
 
         if (!$config->getAppId() || !$config->getApiKey()) {
-            throw new UnreachableException('Missing config: AppId or AppKey. Please check your settings');
+            throw new UnreachableException('Missing config: appId or apiKey. Please check your settings');
         }
 
         $cacheKey = sprintf('%s-clusterHosts-%s', __CLASS__, $config->getAppId());

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
+use Algolia\AlgoliaSearch\Exceptions\UnreachableException;
 use Algolia\AlgoliaSearch\Exceptions\ValidUntilNotFoundException;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\Response\AddApiKeyResponse;
@@ -53,6 +54,10 @@ class SearchClient
     public static function createWithConfig(SearchConfig $config)
     {
         $config = clone $config;
+
+        if (!$config->getAppId() || !$config->getApiKey()) {
+            throw new UnreachableException('Missing config: AppId or AppKey. Please check your settings');
+        }
 
         $cacheKey = sprintf('%s-clusterHosts-%s', __CLASS__, $config->getAppId());
 


### PR DESCRIPTION
…before contacting algolia

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Check if required api settings (apikey and appid) are given in the config array or throw an exception.

## What problem is this fixing?

If an api call is made with missing config information it retries multiple times and then fails with an exception. This generates not needed traffic and causing wait times for users.
This change handels the missing information before making changes and throwing an exception if the information are missing