### PR TITLE
[wip] Add guzzle 7 http client

### DIFF
--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -86,24 +86,34 @@ final class Algolia
 
     public static function getHttpClient()
     {
-        $guzzleVersion = null;
-        if (interface_exists('\GuzzleHttp\ClientInterface')) {
-            if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-                $guzzleVersion = (int) substr(\GuzzleHttp\Client::VERSION, 0, 1);
-            } else {
-                $guzzleVersion = \GuzzleHttp\ClientInterface::MAJOR_VERSION;
-            }
-        }
+        $guzzleVersion = self::resolveGuzzleVersion();
 
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && 6 <= $guzzleVersion) {
-                self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
+            if (class_exists('\GuzzleHttp\Client') && is_int($guzzleVersion) && ($guzzleVersion === 6 || $guzzleVersion === 7)) {
+                if($guzzleVersion === 6) {
+                    self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
+                } else {
+                    self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle7HttpClient());
+                }
             } else {
                 self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Php53HttpClient());
             }
         }
 
         return self::$httpClient;
+    }
+
+    protected static function resolveGuzzleVersion()
+    {
+        if (interface_exists('\GuzzleHttp\ClientInterface')) {
+            if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+                return (int) substr(\GuzzleHttp\Client::VERSION, 0, 1);
+            } else {
+                return \GuzzleHttp\ClientInterface::MAJOR_VERSION;
+            }
+        }
+
+        return null;
     }
 
     public static function setHttpClient(HttpClientInterface $httpClient)

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -89,8 +89,8 @@ final class Algolia
         $guzzleVersion = self::resolveGuzzleVersion();
 
         if (null === self::$httpClient) {
-            if (class_exists('\GuzzleHttp\Client') && is_int($guzzleVersion) && ($guzzleVersion === 6 || $guzzleVersion === 7)) {
-                if($guzzleVersion === 6) {
+            if (class_exists('\GuzzleHttp\Client') && is_int($guzzleVersion) && (6 === $guzzleVersion || 7 === $guzzleVersion)) {
+                if (6 === $guzzleVersion) {
                     self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle6HttpClient());
                 } else {
                     self::setHttpClient(new \Algolia\AlgoliaSearch\Http\Guzzle7HttpClient());

--- a/src/Http/Guzzle7HttpClient.php
+++ b/src/Http/Guzzle7HttpClient.php
@@ -4,8 +4,8 @@ namespace Algolia\AlgoliaSearch\Http;
 
 use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #640   <!-- will close issue automatically, if any -->
| Need Doc update   | /no


## Describe your change

- Add `Guzzle7HttpClient`

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?

- `Guzzle6HttpClient` doesn't catch new Guzzle7's `GuzzleHttp\Exception\RequestException`, and algolia retrying is not working.

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
