### PR TITLE
refactor(synonyms): rename replaceExistingSynonyms parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Encountering an issue? Before reaching out to support, we recommend heading to o
 ## 📄 License
 
 Algolia PHP API Client is an open-sourced software licensed under the [MIT license](LICENSE.md).
+

--- a/src/RequestOptions/RequestOptions.php
+++ b/src/RequestOptions/RequestOptions.php
@@ -280,6 +280,13 @@ final class RequestOptions
         return $this;
     }
 
+    public function deleteBodyParameter($parameter)
+    {
+        unset($this->body[$parameter]);
+
+        return $this;
+    }
+
     /**
      * Replace all existing body parameters with the given name/value pairs.
      *

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -12,7 +12,6 @@ final class RequestOptionsFactory
     private $validQueryParameters = array(
         'forwardToReplicas',
         'replaceExistingSynonyms',
-        'clearExistingSynonyms',
         'clearExistingRules',
         'getVersion',
     );

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -12,6 +12,7 @@ final class RequestOptionsFactory
     private $validQueryParameters = array(
         'forwardToReplicas',
         'replaceExistingSynonyms',
+        'clearExistingSynonyms',
         'clearExistingRules',
         'getVersion',
     );

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -379,6 +379,17 @@ class SearchIndex
 
     public function saveSynonyms($synonyms, $requestOptions = array())
     {
+        if (is_array($requestOptions)) {
+            if (array_key_exists('clearExistingSynonyms', $requestOptions)) {
+                $requestOptions['replaceExistingSynonyms'] = $requestOptions['clearExistingSynonyms'];
+            }
+        } elseif ($requestOptions instanceof RequestOptions) {
+            $bodyParams = $requestOptions->getQueryParameters();
+            if (array_key_exists('clearExistingSynonyms', $bodyParams)) {
+                $requestOptions->addQueryParameter('replaceExistingSynonyms', $bodyParams['clearExistingSynonyms']);
+            }
+        }
+
         $default = array();
         if (is_bool($fwd = $this->config->getDefaultForwardToReplicas())) {
             $default['forwardToReplicas'] = $fwd;
@@ -412,9 +423,9 @@ class SearchIndex
     public function replaceAllSynonyms($synonyms, $requestOptions = array())
     {
         if (is_array($requestOptions)) {
-            $requestOptions['replaceExistingSynonyms'] = true;
+            $requestOptions['clearExistingSynonyms'] = true;
         } elseif ($requestOptions instanceof RequestOptions) {
-            $requestOptions->addQueryParameter('replaceExistingSynonyms', true);
+            $requestOptions->addQueryParameter('clearExistingSynonyms', true);
         }
 
         return $this->saveSynonyms($synonyms, $requestOptions);

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -382,11 +382,13 @@ class SearchIndex
         if (is_array($requestOptions)) {
             if (array_key_exists('clearExistingSynonyms', $requestOptions)) {
                 $requestOptions['replaceExistingSynonyms'] = $requestOptions['clearExistingSynonyms'];
+                unset($requestOptions['clearExistingSynonyms']);
             }
         } elseif ($requestOptions instanceof RequestOptions) {
-            $bodyParams = $requestOptions->getQueryParameters();
+            $bodyParams = $requestOptions->getBody();
             if (array_key_exists('clearExistingSynonyms', $bodyParams)) {
                 $requestOptions->addQueryParameter('replaceExistingSynonyms', $bodyParams['clearExistingSynonyms']);
+                $requestOptions->deleteBodyParameter('clearExistingSynonyms');
             }
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #648 
| Need Doc update   | yes


## Describe your change

In the method `saveSynonyms`, rename the parameter `replaceExistingSynonyms` to `clearExistingSynonyms`