### PR TITLE
Bump to PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.3 || ^7.0 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
Bump composer require dependency to PHP 8.0

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     |
| Need Doc update   | no


## Describe your change

Updates the composer.json to allow running on PHP 8.0

## What problem is this fixing?

Inability to run on PHP 8.0 