### PR TITLE
V3 php8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,9 @@ workflows:
       - test:
           version: "7.4"
           http_client: guzzlehttp/guzzle:"^7.0"
+      - test:
+          version: "7.3"
+          http_client: guzzlehttp/guzzle:"^7.0"
 
       - test:
           version: "latest"
@@ -109,10 +112,7 @@ workflows:
           version: "7.4"
           http_client: guzzlehttp/guzzle:"^6.0"
       - test:
-          version: "7.0"
-          http_client: guzzlehttp/guzzle:"^6.0"
-      - test:
-          version: "5.6"
+          version: "7.3"
           http_client: guzzlehttp/guzzle:"^6.0"
 
       - test:
@@ -122,8 +122,5 @@ workflows:
           version: "7.4"
           http_client: legacy
       - test:
-          version: "7.0"
-          http_client: legacy
-      - test:
-          version: "5.6"
+          version: "7.3"
           http_client: legacy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,8 @@ jobs:
             then
                php vendor/bin/phpunit
             else
-              export CI_PROJ_USERNAME=$CIRCLE_PROJECT_USERNAME
-              export CI_PROJ_REPONAME=$CIRCLE_PROJECT_REPONAME
+              export CI_PROJ_USERNAME=$CIRCLE_PR_USERNAME
+              export CI_PROJ_REPONAME=$CIRCLE_PR_REPONAME
 
               eval $(./algolia-keys export)
               php vendor/bin/phpunit -v --testsuite Unit,Definition,Community

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
     jobs:
       - test:
           version: "latest"
-          http_client: guzzlehttp/guzzle:"^7.0"
+          http_client: guzzlehttp/guzzle:"^7.2"
       - test:
           version: "7.4"
           http_client: guzzlehttp/guzzle:"^7.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
 
       - run:
           name: Check code styles
-          command:
+          command: |
             export PHP_CS_FIXER_IGNORE_ENV=1
             vendor/bin/php-cs-fixer fix -v --dry-run
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ jobs:
 
       - run:
           name: Check code styles
-          command: vendor/bin/php-cs-fixer fix -v --dry-run
+          command:
+            export PHP_CS_FIXER_IGNORE_ENV=1
+            vendor/bin/php-cs-fixer fix -v --dry-run
 
       # Run tests with phpunit
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,6 @@ workflows:
           http_client: guzzlehttp/guzzle:"^7.0"
 
       - test:
-          version: "latest"
-          http_client: guzzlehttp/guzzle:"^6.0"
-      - test:
           version: "7.4"
           http_client: guzzlehttp/guzzle:"^6.0"
       - test:

--- a/.circleci/index-cleanup.php
+++ b/.circleci/index-cleanup.php
@@ -2,7 +2,7 @@
 
 require '../vendor/autoload.php';
 
-$client = Algolia\AlgoliaSearch\SearchClient::create("I2UB5B7IZB", getenv('ALGOLIA_API_KEY'));
+$client = Algolia\AlgoliaSearch\SearchClient::create(getenv('ALGOLIA_APP_ID'), getenv('ALGOLIA_API_KEY'));
 
 $indices = $client->listIndices();
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /tests/cache/
 .idea/
 .php_cs.dist
+.phpunit.result.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,7 +11,7 @@ $config = (new \PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
         'array_syntax' => array('syntax' => 'long'),
-        'increment_style' => array('style' => 'post')
+        'increment_style' => array('style' => 'post'),
     ))
     ->setFinder($finder);
 

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,11 +6,13 @@ $finder = \PhpCsFixer\Finder::create()
     ->in(__DIR__.DIRECTORY_SEPARATOR.'bin')
     ->append(array('.php_cs.dist'));
 
-return \PhpCsFixer\Config::create()
+$config = (new \PhpCsFixer\Config())
     ->setUsingCache(true)
-    ->setRules([
-        '@Symfony'        => true,
-        'array_syntax'    => ['syntax' => 'long'],
-        'increment_style' => ['style' => 'post']
-    ])
+    ->setRules(array(
+        '@Symfony' => true,
+        'array_syntax' => array('syntax' => 'long'),
+        'increment_style' => array('style' => 'post')
+    ))
     ->setFinder($finder);
+
+return $config;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,18 +6,11 @@ $finder = \PhpCsFixer\Finder::create()
     ->in(__DIR__.DIRECTORY_SEPARATOR.'bin')
     ->append(array('.php_cs.dist'));
 
-$rules = array(
-    '@Symfony' => true,
-    'array_syntax' => array('syntax' => 'long'),
-);
-
-if (PHP_VERSION_ID < 50400) {
-    $rules['pre_increment'] = false;
-} else {
-    $rules['increment_style'] = array('style' => 'post');
-}
-
 return \PhpCsFixer\Config::create()
     ->setUsingCache(true)
-    ->setRules($rules)
+    ->setRules([
+        '@Symfony'        => true,
+        'array_syntax'    => ['syntax' => 'long'],
+        'increment_style' => ['style' => 'post']
+    ])
     ->setFinder($finder);

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Dockerfile
 FROM php:7.4.1-fpm
+#FROM php:7.1.0-fpm
+#FROM php:8.0.0-fpm
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Dockerfile
-FROM php:7.4.1-fpm
-#FROM php:7.1.0-fpm
-#FROM php:8.0.0-fpm
+#FROM php:7.3.0-fpm
+FROM php:8.0.0-fpm
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports php `^5.3`.
+- Supports php `^7.3 || ^8.0`.
 
 ## 💡 Getting Started
 

--- a/bin/algolia-doctor
+++ b/bin/algolia-doctor
@@ -23,8 +23,8 @@ class AlgoliaDoctor
 
     public function checkPhpVersion()
     {
-        if (PHP_VERSION_ID < 50300) {
-            echo 'Unfortunately your version of PHP is too old. Consider upgrading to PHP 7+.';
+        if (PHP_VERSION_ID < 70300) {
+            echo 'Unfortunately your version of PHP is too old. Consider upgrading to PHP 7.3+.';
             $this->exitCode = 1;
         }
     }
@@ -47,7 +47,7 @@ class AlgoliaDoctor
 
     public function checkSerializeParam()
     {
-        if (PHP_VERSION_ID > 70100 && '-1' !== ini_get('serialize_precision')) {
+        if ('-1' !== ini_get('serialize_precision')) {
             echo '
 When using PHP 7.1+, you must set the "serialize_precision" ini settings to -1.
 See https://github.com/algolia/algoliasearch-client-php/issues/365
@@ -58,7 +58,7 @@ See https://github.com/algolia/algoliasearch-client-php/issues/365
 
     public function checkHttpClient()
     {
-        if (PHP_VERSION_ID > 50500 && !class_exists('GuzzleHttp\Client')) {
+        if (!class_exists('GuzzleHttp\Client')) {
             echo "
 You're using a recent enough version of PHP to use the Guzzle Http library.
 It's highly recommended to use Guzzle.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
-        "fzaninotto/faker": "^1.8",
+        "fzaninotto/faker": "dev-master",
         "phpunit/phpunit": "^9.3",
         "symfony/yaml": "^2.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -22,7 +22,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "fzaninotto/faker": "^1.8",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^9.3",
         "symfony/yaml": "^2.0 || ^4.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true" bootstrap="tests/bootstrap.php">
-    <ini name="date.timezone" value="UTC"/>
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
     <testsuites>
         <testsuite name="Community">
             <directory suffix="Test.php">tests/Integration/</directory>

--- a/src/AccountClient.php
+++ b/src/AccountClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Cache\NullCacheDriver;

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\AnalyticsConfig;

--- a/src/Cache/FileCacheDriver.php
+++ b/src/Cache/FileCacheDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Cache;
 
 use Psr\SimpleCache\CacheInterface;

--- a/src/Cache/NullCacheDriver.php
+++ b/src/Cache/NullCacheDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Cache;
 
 use Psr\SimpleCache\CacheInterface;

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 abstract class AbstractConfig

--- a/src/Config/AnalyticsConfig.php
+++ b/src/Config/AnalyticsConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 final class AnalyticsConfig extends AbstractConfig

--- a/src/Config/InsightsConfig.php
+++ b/src/Config/InsightsConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 final class InsightsConfig extends AbstractConfig

--- a/src/Config/PlacesConfig.php
+++ b/src/Config/PlacesConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 final class PlacesConfig extends AbstractConfig

--- a/src/Config/RecommendationConfig.php
+++ b/src/Config/RecommendationConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 final class RecommendationConfig extends AbstractConfig

--- a/src/Config/SearchConfig.php
+++ b/src/Config/SearchConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Config;
 
 class SearchConfig extends AbstractConfig

--- a/src/Exceptions/AlgoliaException.php
+++ b/src/Exceptions/AlgoliaException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 class AlgoliaException extends \Exception

--- a/src/Exceptions/BadRequestException.php
+++ b/src/Exceptions/BadRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 class BadRequestException extends RequestException

--- a/src/Exceptions/CannotWaitException.php
+++ b/src/Exceptions/CannotWaitException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 final class CannotWaitException extends AlgoliaException

--- a/src/Exceptions/MissingObjectId.php
+++ b/src/Exceptions/MissingObjectId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 class MissingObjectId extends AlgoliaException

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 final class NotFoundException extends BadRequestException

--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Exceptions/RetriableException.php
+++ b/src/Exceptions/RetriableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 final class RetriableException extends RequestException

--- a/src/Exceptions/UnreachableException.php
+++ b/src/Exceptions/UnreachableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 final class UnreachableException extends AlgoliaException

--- a/src/Exceptions/ValidUntilNotFoundException.php
+++ b/src/Exceptions/ValidUntilNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Exceptions;
 
 final class ValidUntilNotFoundException extends AlgoliaException

--- a/src/Http/Guzzle6HttpClient.php
+++ b/src/Http/Guzzle6HttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http;
 
 use Algolia\AlgoliaSearch\Http\Psr7\Response;

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Http/Php53HttpClient.php
+++ b/src/Http/Php53HttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http;
 
 use Algolia\AlgoliaSearch\Http\Psr7\Response;

--- a/src/Http/Psr7/BufferStream.php
+++ b/src/Http/Psr7/BufferStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/Http/Psr7/PumpStream.php
+++ b/src/Http/Psr7/PumpStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -302,7 +302,7 @@ class Request implements RequestInterface
     private function trimHeaderValues(array $values)
     {
         return array_map(function ($value) {
-            return trim($value, " \t");
+            return trim((string) $value, " \t");
         }, $values);
     }
 }

--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use InvalidArgumentException;

--- a/src/Http/Psr7/Response.php
+++ b/src/Http/Psr7/Response.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Http/Psr7/Stream.php
+++ b/src/Http/Psr7/Stream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\UriInterface;

--- a/src/Http/Psr7/UriResolver.php
+++ b/src/Http/Psr7/UriResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\UriInterface;

--- a/src/Http/Psr7/functions.php
+++ b/src/Http/Psr7/functions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/Insights/UserInsightsClient.php
+++ b/src/Insights/UserInsightsClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Insights;
 
 use Algolia\AlgoliaSearch\InsightsClient;

--- a/src/InsightsClient.php
+++ b/src/InsightsClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\InsightsConfig;

--- a/src/Iterators/AbstractAlgoliaIterator.php
+++ b/src/Iterators/AbstractAlgoliaIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;

--- a/src/Iterators/ObjectIterator.php
+++ b/src/Iterators/ObjectIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;

--- a/src/Iterators/RuleIterator.php
+++ b/src/Iterators/RuleIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;

--- a/src/Iterators/SynonymIterator.php
+++ b/src/Iterators/SynonymIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Iterators;
 
 use Algolia\AlgoliaSearch\Support\Helpers;

--- a/src/Log/DebugLogger.php
+++ b/src/Log/DebugLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Log;
 
 use Psr\Log\AbstractLogger;

--- a/src/PlacesClient.php
+++ b/src/PlacesClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\PlacesConfig;

--- a/src/RecommendationClient.php
+++ b/src/RecommendationClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\RecommendationConfig;

--- a/src/RequestOptions/RequestOptions.php
+++ b/src/RequestOptions/RequestOptions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RequestOptions;
 
 use Algolia\AlgoliaSearch\Support\Helpers;

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -121,7 +121,7 @@ final class RequestOptionsFactory
 
     private function isValidHeaderName($name)
     {
-        if (preg_match('/^X-[a-zA-Z-]+/', $name)) {
+        if (preg_match('/^X-[a-zA-Z-]+/', (string) $name)) {
             return true;
         }
 

--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RequestOptions;
 
 use Algolia\AlgoliaSearch\Config\AbstractConfig;

--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 abstract class AbstractResponse implements \ArrayAccess

--- a/src/Response/AddApiKeyResponse.php
+++ b/src/Response/AddApiKeyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/Response/AddApiKeyResponse.php
+++ b/src/Response/AddApiKeyResponse.php
@@ -50,7 +50,7 @@ final class AddApiKeyResponse extends AbstractResponse
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * $time); // 0.1 second
+            usleep((int) ($factor * $time)); // 0.1 second
         } while (true);
     }
 }

--- a/src/Response/BatchIndexingResponse.php
+++ b/src/Response/BatchIndexingResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchIndex;

--- a/src/Response/DeleteApiKeyResponse.php
+++ b/src/Response/DeleteApiKeyResponse.php
@@ -53,7 +53,7 @@ final class DeleteApiKeyResponse extends AbstractResponse
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * $time); // 0.1 second
+            usleep((int) ($factor * $time)); // 0.1 second
         } while (true);
     }
 }

--- a/src/Response/DeleteApiKeyResponse.php
+++ b/src/Response/DeleteApiKeyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/Response/IndexingResponse.php
+++ b/src/Response/IndexingResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchIndex;

--- a/src/Response/MultiResponse.php
+++ b/src/Response/MultiResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 class MultiResponse extends AbstractResponse implements \Iterator, \Countable

--- a/src/Response/MultipleIndexBatchIndexingResponse.php
+++ b/src/Response/MultipleIndexBatchIndexingResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\SearchClient;

--- a/src/Response/NullResponse.php
+++ b/src/Response/NullResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 final class NullResponse extends AbstractResponse

--- a/src/Response/RestoreApiKeyResponse.php
+++ b/src/Response/RestoreApiKeyResponse.php
@@ -7,6 +7,7 @@ namespace Algolia\AlgoliaSearch\Response;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\SearchClient;
+use function usleep;
 
 final class RestoreApiKeyResponse extends AbstractResponse
 {
@@ -63,7 +64,7 @@ final class RestoreApiKeyResponse extends AbstractResponse
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * $time); // 0.1 second
+            usleep((int) ($factor * $time)); // 0.1 second
         } while (true);
     }
 }

--- a/src/Response/RestoreApiKeyResponse.php
+++ b/src/Response/RestoreApiKeyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/Response/UpdateApiKeyResponse.php
+++ b/src/Response/UpdateApiKeyResponse.php
@@ -7,6 +7,7 @@ namespace Algolia\AlgoliaSearch\Response;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use Algolia\AlgoliaSearch\SearchClient;
+use function usleep;
 
 final class UpdateApiKeyResponse extends AbstractResponse
 {
@@ -59,7 +60,7 @@ final class UpdateApiKeyResponse extends AbstractResponse
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * $time); // 0.1 second
+            usleep((int) ($factor * $time)); // 0.1 second
         } while (true);
     }
 

--- a/src/Response/UpdateApiKeyResponse.php
+++ b/src/Response/UpdateApiKeyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Response;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/RetryStrategy/ApiWrapper.php
+++ b/src/RetryStrategy/ApiWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 use Algolia\AlgoliaSearch\Algolia;

--- a/src/RetryStrategy/ApiWrapperInterface.php
+++ b/src/RetryStrategy/ApiWrapperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 interface ApiWrapperInterface

--- a/src/RetryStrategy/ClusterHosts.php
+++ b/src/RetryStrategy/ClusterHosts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 use Algolia\AlgoliaSearch\Algolia;

--- a/src/RetryStrategy/Host.php
+++ b/src/RetryStrategy/Host.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 /**

--- a/src/RetryStrategy/HostCollection.php
+++ b/src/RetryStrategy/HostCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 /**

--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -617,7 +617,7 @@ class SearchIndex
 
             $retry++;
             $factor = ceil($retry / 10);
-            usleep($factor * $time); // 0.1 second
+            usleep((int) ($factor * $time)); // 0.1 second
         } while (true);
     }
 

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -29,7 +29,7 @@ final class Helpers
     {
         $arguments = array_slice(func_get_args(), 1);
         foreach ($arguments as &$arg) {
-            $arg = urlencode(urldecode($arg));
+            $arg = urlencode(urldecode((string) $arg));
         }
         array_unshift($arguments, $pathFormat);
 

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Support;
 
 use Algolia\AlgoliaSearch\Exceptions\MissingObjectId;

--- a/src/Support/UserAgent.php
+++ b/src/Support/UserAgent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Support;
 
 use Algolia\AlgoliaSearch\Algolia;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch;
 
 function api_path($pathFormat, $args = null, $_ = null)

--- a/tests/API/MethodConsistentConstraint.php
+++ b/tests/API/MethodConsistentConstraint.php
@@ -1,32 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\API;
 
-class MethodConsistentConstraint extends \PHPUnit_Framework_Constraint
+class MethodConsistentConstraint extends \PHPUnit\Framework\Constraint\Constraint
 {
     private $instance;
 
     public function __construct($instance)
     {
-        parent::__construct();
         $this->instance = $instance;
     }
 
-    public function evaluate($definition, $description = '', $returnResult = false)
+    public function evaluate($definition, string $description = '', bool $returnResult = false): ?bool
     {
         if (!method_exists($this->instance, $definition['method'])) {
             $description = 'The method '.$definition['method'].' is not implemented.';
 
-            return $returnResult ? false : $this->fail($definition, $description);
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail($definition, $description);
         }
 
         $refl = new \ReflectionMethod($this->instance, $definition['method']);
         $argsImplemented = $refl->getParameters();
 
         if (count($argsImplemented) != count($definition['args'])) {
-            return $returnResult ?
-                false :
-                $this->fail($definition, 'The method '.$definition['method'].' has a wong number of arguments.');
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail($definition, 'The method '.$definition['method'].' has a wong number of arguments.');
         }
         $success = true;
         foreach ($argsImplemented as $arg) {
@@ -69,18 +76,22 @@ class MethodConsistentConstraint extends \PHPUnit_Framework_Constraint
         }
 
         if (!$success) {
-            return $returnResult ? false : $this->fail($definition, $description);
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail($definition, $description);
         }
 
         return true;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return '';
     }
 
-    protected function failureDescription($other)
+    protected function failureDescription($other): string
     {
         return sprintf(
             'the object %s has the method %s correctly implemented',

--- a/tests/API/PublicApiChecker.php
+++ b/tests/API/PublicApiChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\API;
 
 use PHPUnit\Framework\Assert;

--- a/tests/API/PublicApiTest.php
+++ b/tests/API/PublicApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\API;
 
 use Algolia\AlgoliaSearch\Algolia;
@@ -10,12 +12,12 @@ use Symfony\Component\Yaml\Yaml;
 
 class PublicApiTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Algolia::setHttpClient(new NullHttpClient());
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         Algolia::resetHttpClient();

--- a/tests/ArraySubsetConstraint.php
+++ b/tests/ArraySubsetConstraint.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * Constraint that asserts that the array it is evaluated for has a specified subset.
+ *
+ * Uses array_replace_recursive() to check if a key value subset is part of the
+ * subject array.
+ *
+ * This code was taken from PHPUnit\Framework\Constraint\ArraySubset which was deprecated and then removed.
+ *
+ * @codeCoverageIgnore
+ */
+final class ArraySubsetConstraint extends Constraint
+{
+    /**
+     * @var iterable
+     */
+    private $subset;
+
+    /**
+     * @var bool
+     */
+    private $strict;
+
+    public function __construct(iterable $subset, bool $strict = false)
+    {
+        $this->strict = $strict;
+        $this->subset = $subset;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
+    {
+        //type cast $other & $this->subset as an array to allow
+        //support in standard array functions.
+        $other        = $this->toArray($other);
+        $this->subset = $this->toArray($this->subset);
+
+        $patched = \array_replace_recursive($other, $this->subset);
+
+        if ($this->strict) {
+            $result = $other === $patched;
+        } else {
+            $result = $other == $patched;
+        }
+
+        if ($returnResult) {
+            return true;
+        }
+
+        if (!$result) {
+            $f = new ComparisonFailure(
+                $patched,
+                $other,
+                \var_export($patched, true),
+                \var_export($other, true)
+            );
+
+            $this->fail($other, $description, $f);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function toString(): string
+    {
+        return 'has the subset ' . $this->exporter()->export($this->subset);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+
+    private function toArray(iterable $other): array
+    {
+        if (\is_array($other)) {
+            return $other;
+        }
+
+        if ($other instanceof \ArrayObject) {
+            return $other->getArrayCopy();
+        }
+
+        if ($other instanceof \Traversable) {
+            return \iterator_to_array($other);
+        }
+
+        // Keep BC even if we know that array would not be the expected one
+        return (array) $other;
+    }
+}

--- a/tests/ArraySubsetConstraint.php
+++ b/tests/ArraySubsetConstraint.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Algolia\AlgoliaSearch\Tests;
 
 use PHPUnit\Framework\Constraint\Constraint;
-use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
 final class ArraySubsetConstraint extends Constraint
@@ -26,19 +25,6 @@ final class ArraySubsetConstraint extends Constraint
         $this->subset = $subset;
     }
 
-    /**
-     * Evaluates the constraint for parameter $other
-     *
-     * If $returnResult is set to false (the default), an exception is thrown
-     * in case of a failure. null is returned otherwise.
-     *
-     * If $returnResult is true, the result of the evaluation is returned as
-     * a boolean value instead: true in case of success, false in case of a
-     * failure
-     *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
     public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         //type cast $other & $this->subset as an array to allow
@@ -72,26 +58,11 @@ final class ArraySubsetConstraint extends Constraint
         return null;
     }
 
-    /**
-     * Returns a string representation of the constraint.
-     *
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
     public function toString(): string
     {
         return 'has the subset '.$this->exporter()->export($this->subset);
     }
 
-    /**
-     * Returns the description of the failure
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     *
-     * @param mixed $other evaluated value or object
-     *
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
     protected function failureDescription($other): string
     {
         return 'an array '.$this->toString();

--- a/tests/ArraySubsetConstraint.php
+++ b/tests/ArraySubsetConstraint.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Algolia\AlgoliaSearch\Tests;
 

--- a/tests/ArraySubsetConstraint.php
+++ b/tests/ArraySubsetConstraint.php
@@ -8,16 +8,6 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
-/**
- * Constraint that asserts that the array it is evaluated for has a specified subset.
- *
- * Uses array_replace_recursive() to check if a key value subset is part of the
- * subject array.
- *
- * This code was taken from PHPUnit\Framework\Constraint\ArraySubset which was deprecated and then removed.
- *
- * @codeCoverageIgnore
- */
 final class ArraySubsetConstraint extends Constraint
 {
     /**
@@ -44,7 +34,7 @@ final class ArraySubsetConstraint extends Constraint
      *
      * If $returnResult is true, the result of the evaluation is returned as
      * a boolean value instead: true in case of success, false in case of a
-     * failure.
+     * failure
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
@@ -53,7 +43,7 @@ final class ArraySubsetConstraint extends Constraint
     {
         //type cast $other & $this->subset as an array to allow
         //support in standard array functions.
-        $other        = $this->toArray($other);
+        $other = $this->toArray($other);
         $this->subset = $this->toArray($this->subset);
 
         $patched = \array_replace_recursive($other, $this->subset);
@@ -89,7 +79,7 @@ final class ArraySubsetConstraint extends Constraint
      */
     public function toString(): string
     {
-        return 'has the subset ' . $this->exporter()->export($this->subset);
+        return 'has the subset '.$this->exporter()->export($this->subset);
     }
 
     /**
@@ -104,7 +94,7 @@ final class ArraySubsetConstraint extends Constraint
      */
     protected function failureDescription($other): string
     {
-        return 'an array ' . $this->toString();
+        return 'an array '.$this->toString();
     }
 
     private function toArray(iterable $other): array

--- a/tests/AssertArraySubsetTrait.php
+++ b/tests/AssertArraySubsetTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Algolia\AlgoliaSearch\Tests;
 

--- a/tests/AssertArraySubsetTrait.php
+++ b/tests/AssertArraySubsetTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use ArrayAccess;
+use Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+
+/**
+ * @mixin TestCase
+ */
+trait AssertArraySubsetTrait
+{
+
+    /**
+     * Asserts that an array has a specified subset.
+     *
+     * @param array|ArrayAccess $subset
+     * @param array|ArrayAccess $array
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     *
+     * @codeCoverageIgnore
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3494
+     */
+    public static function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
+    {
+        if (!(\is_array($subset) || $subset instanceof ArrayAccess)) {
+            throw new InvalidArgumentException(
+                1,
+                'array or ArrayAccess'
+            );
+        }
+
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
+            throw new InvalidArgumentException(
+                2,
+                'array or ArrayAccess'
+            );
+        }
+
+        $constraint = new ArraySubsetConstraint($subset, $checkForObjectIdentity);
+
+        static::assertThat($array, $constraint, $message);
+    }
+}

--- a/tests/AssertArraySubsetTrait.php
+++ b/tests/AssertArraySubsetTrait.php
@@ -15,7 +15,6 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
  */
 trait AssertArraySubsetTrait
 {
-
     /**
      * Asserts that an array has a specified subset.
      *
@@ -27,23 +26,15 @@ trait AssertArraySubsetTrait
      * @throws Exception
      *
      * @codeCoverageIgnore
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3494
      */
     public static function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
     {
         if (!(\is_array($subset) || $subset instanceof ArrayAccess)) {
-            throw new InvalidArgumentException(
-                1,
-                'array or ArrayAccess'
-            );
+            throw new InvalidArgumentException(1, 'array or ArrayAccess');
         }
 
         if (!(\is_array($array) || $array instanceof ArrayAccess)) {
-            throw new InvalidArgumentException(
-                2,
-                'array or ArrayAccess'
-            );
+            throw new InvalidArgumentException(2, 'array or ArrayAccess');
         }
 
         $constraint = new ArraySubsetConstraint($subset, $checkForObjectIdentity);

--- a/tests/Integration/AlgoliaIntegrationTestCase.php
+++ b/tests/Integration/AlgoliaIntegrationTestCase.php
@@ -6,11 +6,14 @@ namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Tests\AssertArraySubsetTrait;
 use Algolia\AlgoliaSearch\Tests\SyncClient;
 use PHPUnit\Framework\TestCase as PHPUitTestCase;
 
 abstract class AlgoliaIntegrationTestCase extends PHPUitTestCase
 {
+    use AssertArraySubsetTrait;
+
     protected static $indexes = array();
 
     private static $instance;

--- a/tests/Integration/AlgoliaIntegrationTestCase.php
+++ b/tests/Integration/AlgoliaIntegrationTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
@@ -16,13 +18,13 @@ abstract class AlgoliaIntegrationTestCase extends PHPUitTestCase
     /** @var SyncClient */
     private static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         static::$indexes = array();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
 

--- a/tests/Integration/AnalyticsClientTest.php
+++ b/tests/Integration/AnalyticsClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\AnalyticsClient;
@@ -8,7 +10,7 @@ use DateTime;
 
 class AnalyticsClientTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/BrowseAndIteratorsTest.php
+++ b/tests/Integration/BrowseAndIteratorsTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class BrowseAndIteratorsTest extends AlgoliaIntegrationTestCase
 {
     protected static $index;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!isset(static::$indexes['main'])) {
             static::$indexes['main'] = static::safeName('browse-and-iterators');

--- a/tests/Integration/FileCacheDriverTest.php
+++ b/tests/Integration/FileCacheDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Algolia;
@@ -11,7 +13,7 @@ class FileCacheDriverTest extends AlgoliaIntegrationTestCase
 {
     private static $cacheDir;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -23,7 +25,7 @@ class FileCacheDriverTest extends AlgoliaIntegrationTestCase
         Algolia::setCache(new FileCacheDriver(self::$cacheDir));
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         Algolia::setCache(new NullCacheDriver());

--- a/tests/Integration/IndexManagementTest.php
+++ b/tests/Integration/IndexManagementTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class IndexManagementTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -13,11 +15,11 @@ class IndexManagementTest extends AlgoliaIntegrationTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 

--- a/tests/Integration/IndexingTest.php
+++ b/tests/Integration/IndexingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Response\MultiResponse;
@@ -9,7 +11,7 @@ use Faker\Factory;
 
 class IndexingTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         static::$indexes['main'] = self::safeName('indexing');
@@ -87,7 +89,7 @@ class IndexingTest extends AlgoliaIntegrationTestCase
         self::assertCount(1006, $iterator);
         $results = iterator_to_array($iterator);
         foreach ($objects as $object) {
-            self::assertContains($object, $results);
+            self::assertContainsEquals($object, $results);
         }
 
         /* Alter 1 record with partialUpdateObject */

--- a/tests/Integration/InsightsClientTest.php
+++ b/tests/Integration/InsightsClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\InsightsClient;
@@ -7,7 +9,7 @@ use Algolia\AlgoliaSearch\SearchClient;
 
 class InsightsClientTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         static::$indexes['insights'] = self::safeName('insights');

--- a/tests/Integration/KeysTest.php
+++ b/tests/Integration/KeysTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class KeysTest extends AlgoliaIntegrationTestCase
@@ -11,7 +13,7 @@ class KeysTest extends AlgoliaIntegrationTestCase
         'maxHitsPerQuery' => 2,
     );
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/LogsTest.php
+++ b/tests/Integration/LogsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class LogsTest extends AlgoliaIntegrationTestCase

--- a/tests/Integration/MultiClusterManagementTest.php
+++ b/tests/Integration/MultiClusterManagementTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
@@ -19,7 +21,7 @@ class MultiClusterManagementTest extends AlgoliaIntegrationTestCase
     /** @var string */
     private $mcmUserId2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/MultipleIndexTest.php
+++ b/tests/Integration/MultipleIndexTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class MultipleIndexTest extends AlgoliaIntegrationTestCase

--- a/tests/Integration/PersonalizationStrategyTest.php
+++ b/tests/Integration/PersonalizationStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;

--- a/tests/Integration/PlacesTest.php
+++ b/tests/Integration/PlacesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\PlacesClient;

--- a/tests/Integration/RulesTest.php
+++ b/tests/Integration/RulesTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class RulesTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/SearchClientTest.php
+++ b/tests/Integration/SearchClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\SearchClient;

--- a/tests/Integration/SearchIndexTest.php
+++ b/tests/Integration/SearchIndexTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\SearchIndex;
 
 class SearchIndexTest extends AlgoliaIntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 use Algolia\AlgoliaSearch\Response\MultiResponse;
@@ -8,7 +10,7 @@ class SettingsTest extends AlgoliaIntegrationTestCase
 {
     private $settings = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -88,7 +88,7 @@ class SettingsTest extends AlgoliaIntegrationTestCase
 
         /* Get the settings with getSettings  */
         $retrievedSettings = $index->getSettings();
-        self::assertArraySubset($this->settings, $retrievedSettings);
+        $this->assertArraySubset($this->settings, $retrievedSettings);
 
         /* Set the settings with the following parameters with setSettings */
         $responses[] = $index->setSettings(array('typoTolerance' => 'min', 'ignorePlurals' => array('en', 'fr'), 'removeStopWords' => array('en', 'fr'), 'distinct' => true));
@@ -105,7 +105,7 @@ class SettingsTest extends AlgoliaIntegrationTestCase
         $settingsCopy['distinct'] = true;
 
         $retrievedSettings = $index->getSettings();
-        self::assertArraySubset($settingsCopy, $retrievedSettings);
+        $this->assertArraySubset($settingsCopy, $retrievedSettings);
     }
 
     /**

--- a/tests/Integration/SynonymsTest.php
+++ b/tests/Integration/SynonymsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Integration;
 
 class SynonymsTest extends AlgoliaIntegrationTestCase
@@ -22,7 +24,7 @@ class SynonymsTest extends AlgoliaIntegrationTestCase
         'synonyms' => array('city', 'town', 'village'),
     );
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/NullHttpClient.php
+++ b/tests/NullHttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests;
 
 use Algolia\AlgoliaSearch\Http\HttpClientInterface;

--- a/tests/RequestHttpClient.php
+++ b/tests/RequestHttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests;
 
 use Algolia\AlgoliaSearch\Exceptions\RequestException;

--- a/tests/SyncClient.php
+++ b/tests/SyncClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests;
 
 use Algolia\AlgoliaSearch\Response\AbstractResponse;

--- a/tests/Unit/CopyResourcesTest.php
+++ b/tests/Unit/CopyResourcesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Exceptions\RequestException;
@@ -10,7 +12,7 @@ class CopyResourcesTest extends RequestTestCase
     /** @var \Algolia\AlgoliaSearch\SearchClient */
     private static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         static::$client = SearchClient::create('id', 'key');

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -72,11 +72,10 @@ class HelpersTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Algolia\AlgoliaSearch\Exceptions\MissingObjectId
-     */
     public function testMapObjectIDsWithMissingPrimary()
     {
+        $this->expectException(\Algolia\AlgoliaSearch\Exceptions\MissingObjectId::class);
+
         $objects = array(array('name' => 'test'), array('primary' => 1, 'name' => 'cool'));
         Helpers::mapObjectIDs('primary', $objects);
     }

--- a/tests/Unit/HttpClientsTest.php
+++ b/tests/Unit/HttpClientsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 class HttpClientsTest

--- a/tests/Unit/InsightsClientTest.php
+++ b/tests/Unit/InsightsClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Exceptions\RequestException;
@@ -10,7 +12,7 @@ class InsightsClientTest extends RequestTestCase
     /** @var InsightsClient */
     private static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::$client = InsightsClient::create('id', 'key', 'region');

--- a/tests/Unit/NullTestCase.php
+++ b/tests/Unit/NullTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Algolia;
@@ -12,14 +14,14 @@ class NullTestCase extends TestCase
     /** @var \Algolia\AlgoliaSearch\SearchClient */
     protected static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         Algolia::setHttpClient(new NullHttpClient());
         static::$client = SearchClient::create('id', 'key');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         Algolia::resetHttpClient();

--- a/tests/Unit/RequestOptionsFactoryTest.php
+++ b/tests/Unit/RequestOptionsFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
@@ -12,7 +14,7 @@ class RequestOptionsFactoryTest extends TestCase
     /** @var RequestOptionsFactory */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new RequestOptionsFactory(
             new SearchConfig(array(

--- a/tests/Unit/RequestTestCase.php
+++ b/tests/Unit/RequestTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Algolia;
@@ -9,13 +11,13 @@ use Psr\Http\Message\RequestInterface;
 
 abstract class RequestTestCase extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         Algolia::setHttpClient(new RequestHttpClient());
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         Algolia::resetHttpClient();

--- a/tests/Unit/RequestTestCase.php
+++ b/tests/Unit/RequestTestCase.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Tests\AssertArraySubsetTrait;
 use Algolia\AlgoliaSearch\Tests\RequestHttpClient;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 abstract class RequestTestCase extends TestCase
 {
+    use AssertArraySubsetTrait;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();

--- a/tests/Unit/ResponseObjectTest.php
+++ b/tests/Unit/ResponseObjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 class ResponseObjectTest extends NullTestCase

--- a/tests/Unit/SearchIndexTest.php
+++ b/tests/Unit/SearchIndexTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
 use Algolia\AlgoliaSearch\SearchClient;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert;
 
 class SearchIndexTest extends TestCase
 {
@@ -16,7 +18,7 @@ class SearchIndexTest extends TestCase
     /** @var RequestOptionsFactory */
     protected $requestOptionsFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = SearchConfig::create('foo', 'bar');
         $this->requestOptionsFactory = new RequestOptionsFactory($this->config);
@@ -25,13 +27,13 @@ class SearchIndexTest extends TestCase
     public function testFindObject()
     {
         // Test without requestOptions
-        $apiWrapperMock = $this->getMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
+        $apiWrapperMock = $this->createMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
                 Assert::assertEquals($requestOptions->getBody(), array('page' => 0, 'query' => ''));
 
-                return $requestOptions;
+                return true;
             }))
             ->willReturn(array(
                 'hits' => array(array('foo' => 'bar')),
@@ -44,13 +46,13 @@ class SearchIndexTest extends TestCase
         );
 
         // Test with requestOptions as an array
-        $apiWrapperMock = $this->getMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
+        $apiWrapperMock = $this->createMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
                 Assert::assertEquals($requestOptions->getBody(), array('page' => 0, 'query' => 'foo', 'hitsPerPage' => 5));
 
-                return $requestOptions;
+                return true;
             }))
             ->willReturn(array(
                 'hits' => array(array('foo' => 'bar')),
@@ -64,14 +66,14 @@ class SearchIndexTest extends TestCase
         );
 
         // Test with requestOptions as a RequestOptions object
-        $apiWrapperMock = $this->getMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
+        $apiWrapperMock = $this->createMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
                 Assert::assertEquals($requestOptions->getBody(), array('page' => 0, 'query' => ''));
                 Assert::assertArraySubset(array('User-Agent' => 'blabla'), $requestOptions->getHeaders());
 
-                return $requestOptions;
+                return true;
             }))
             ->willReturn(array(
                 'hits' => array(array('foo' => 'bar')),
@@ -88,14 +90,14 @@ class SearchIndexTest extends TestCase
     public function testExistsWithRequestOptions()
     {
         $requestOptions = $this->requestOptionsFactory->create(array('X-Algolia-User-ID' => 'foo'));
-        $apiWrapperMock = $this->getMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
+        $apiWrapperMock = $this->createMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
 
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
                 Assert::assertArraySubset(array('X-Algolia-User-ID' => 'foo'), $requestOptions->getHeaders());
 
-                return $requestOptions;
+                return true;
             }))
             ->willReturn(array(
                 'hitsPerPage' => 31,
@@ -107,15 +109,15 @@ class SearchIndexTest extends TestCase
 
     public function testExistsWithoutRequestOptions()
     {
-        $apiWrapperMock = $this->getMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
+        $apiWrapperMock = $this->createMock('Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface');
 
         // getVersion is added by default in requestOptions
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
-                Assert::assertInternalType('array', $requestOptions);
+                Assert::assertIsArray($requestOptions);
                 Assert::assertArraySubset(array('getVersion' => 2), $requestOptions);
 
-                return $requestOptions;
+                return true;
             }))
             ->willReturn(array(
                 'hitsPerPage' => 31,

--- a/tests/Unit/SearchIndexTest.php
+++ b/tests/Unit/SearchIndexTest.php
@@ -7,11 +7,14 @@ namespace Algolia\AlgoliaSearch\Tests\Unit;
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
 use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Tests\AssertArraySubsetTrait;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Assert;
 
 class SearchIndexTest extends TestCase
 {
+    use AssertArraySubsetTrait;
+
     /** @var SearchConfig */
     protected $config;
 
@@ -71,7 +74,7 @@ class SearchIndexTest extends TestCase
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
                 Assert::assertEquals($requestOptions->getBody(), array('page' => 0, 'query' => ''));
-                Assert::assertArraySubset(array('User-Agent' => 'blabla'), $requestOptions->getHeaders());
+                $this->assertArraySubset(array('User-Agent' => 'blabla'), $requestOptions->getHeaders());
 
                 return true;
             }))
@@ -95,7 +98,11 @@ class SearchIndexTest extends TestCase
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertInstanceOf('Algolia\AlgoliaSearch\RequestOptions\RequestOptions', $requestOptions);
-                Assert::assertArraySubset(array('X-Algolia-User-ID' => 'foo'), $requestOptions->getHeaders());
+
+                $headers = $requestOptions->getHeaders();
+
+                Assert::assertArrayHasKey('X-Algolia-User-ID', $headers);
+                Assert::assertEquals('foo', $headers['X-Algolia-User-ID']);
 
                 return true;
             }))
@@ -115,7 +122,8 @@ class SearchIndexTest extends TestCase
         $apiWrapperMock->method('read')
             ->with($this->anything(), $this->anything(), $this->callback(function ($requestOptions) {
                 Assert::assertIsArray($requestOptions);
-                Assert::assertArraySubset(array('getVersion' => 2), $requestOptions);
+                Assert::assertArrayHasKey('getVersion', $requestOptions);
+                Assert::assertEquals($requestOptions['getVersion'], 2);
 
                 return true;
             }))

--- a/tests/Unit/SearchIndexTest.php
+++ b/tests/Unit/SearchIndexTest.php
@@ -8,8 +8,8 @@ use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
 use Algolia\AlgoliaSearch\SearchClient;
 use Algolia\AlgoliaSearch\Tests\AssertArraySubsetTrait;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
 
 class SearchIndexTest extends TestCase
 {

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Exceptions\RequestException;

--- a/tests/Unit/UserAgentTest.php
+++ b/tests/Unit/UserAgentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Tests\Unit;
 
 use Algolia\AlgoliaSearch\Algolia;
@@ -10,7 +12,7 @@ class UserAgentTest extends TestCase
 {
     private $default;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->default = 'Algolia for PHP ('.Algolia::VERSION.'); ';
         $this->default .= 'PHP ('.rtrim(str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION), '-').')';
@@ -28,7 +30,8 @@ class UserAgentTest extends TestCase
 
     public function testDefaultUserAgent()
     {
-        $this->assertRegExp('/^Algolia for PHP \(\d+\.\d+\.\d+\); PHP \(\d+\.\d+\.\d+\).*$/', UserAgent::get());
+        $this->assertMatchesRegularExpression('/^Algolia for PHP \(\d+\.\d+\.\d+\); PHP \(\d+\.\d+\.\d+\).*$/',
+            UserAgent::get());
 
         $this->assertEquals($this->default, UserAgent::get());
     }

--- a/tests/tests-no-composer.php
+++ b/tests/tests-no-composer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 passthru(dirname(__DIR__).'/bin/install-dependencies-without-composer');
 
 require_once dirname(__DIR__).'/autoload.php';


### PR DESCRIPTION
| Q                           | A
| ------------------------- | ----------
| Bug fix?                  | no
| New feature?          | yes
| BC breaks?             | yes  
| Related Issue          | 
| Need Doc update    | yes


## Describe your change

I fixed support with PHP 8. For that I had to use PHPUnit ^9.3 and drop support for PHP 5.3. PHP is now at ^7.1 || ^8.0. Had to do a minimum of 7.1 because PHPUnit 9 uses void return types. 

Big thing here is it drops support for PHP ^5.3. Look at the composer.json for more. 

I also created backwards compatability for PHPUnit by creating a AssertArraySubseTrait. There were ->assertArraySubset() calls that were deprecated in PHPUnit 8 and removed completely in PHPUnit 9. 

I do get 2 errors still because my Algolia account doesn't have certain enterprise features. 

There were 2 errors:

1) Algolia\AlgoliaSearch\Tests\Integration\MultiClusterManagementTest::testMultiClusterManagement
Algolia\AlgoliaSearch\Exceptions\UnreachableException: Impossible to connect, please check your Algolia Application Id.

/home/thadbry/www/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:198
/home/thadbry/www/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:89
/home/thadbry/www/algoliasearch-client-php/src/SearchClient.php:294
/home/thadbry/www/algoliasearch-client-php/tests/Integration/MultiClusterManagementTest.php:41

2) Algolia\AlgoliaSearch\Tests\Integration\PersonalizationStrategyTest::testPersonalizationStrategy
Algolia\AlgoliaSearch\Exceptions\BadRequestException: Feature "recommendation" not available in your plan

/home/thadbry/www/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:221
/home/thadbry/www/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:169
/home/thadbry/www/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:103
/home/thadbry/www/algoliasearch-client-php/src/RecommendationClient.php:88
/home/thadbry/www/algoliasearch-client-php/tests/Integration/PersonalizationStrategyTest.php:38

ERRORS!
Tests: 63, Assertions: 1312, Errors: 2.


## What problem is this fixing?

This fixes support for PHP 8. Which is blocking other projects that use this repository including laravel/scout. 
