### PR TITLE
fix(CI): use correct env variables for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
             then
                php vendor/bin/phpunit
             else
-              export CI_PROJ_USERNAME=$CIRCLE_PROJECT_USERNAME
-              export CI_PROJ_REPONAME=$CIRCLE_PROJECT_REPONAME
+              export CI_PROJ_USERNAME=$CIRCLE_PR_USERNAME
+              export CI_PROJ_REPONAME=$CIRCLE_PR_REPONAME
 
               eval $(./algolia-keys export)
               php vendor/bin/phpunit -v --testsuite Unit,Definition,Community


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change
This updates the env variables we use before running the API key dealer.

## What problem is this fixing?
The current variables in use are not [set by CirlceCI](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables), which will result in failing tests for PRs from forked repositories. This is the same error as fixed in https://github.com/algolia/scout-extended/pull/258.