### PR TITLE
Handling of params array in the $queries array for multipleQueries method

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -155,6 +155,14 @@ class SearchClient
 
     public function multipleQueries($queries, $requestOptions = array())
     {
+        $queries = array_map(function($query) {
+            $query['params'] = isset($query['params']) ?
+                Helpers::serializeQueryParameters($query['params']) :
+                Helpers::serializeQueryParameters(array());
+
+            return $query;
+        }, $queries);
+
         if (is_array($requestOptions)) {
             $requestOptions['requests'] = $queries;
         } elseif ($requestOptions instanceof RequestOptions) {

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -126,4 +126,19 @@ final class Helpers
             return $object;
         }, $objects);
     }
+
+    public static function serializeQueryParameters($parameters)
+    {
+        if (is_string($parameters)) {
+            return $parameters;
+        }
+
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                $parameters[$key] = json_encode($value, JSON_THROW_ON_ERROR);
+            }
+        }
+
+        return http_build_query($parameters);
+    }
 }

--- a/tests/Integration/MultipleIndexTest.php
+++ b/tests/Integration/MultipleIndexTest.php
@@ -14,8 +14,8 @@ class MultipleIndexTest extends AlgoliaIntegrationTestCase
         $result = $client->multipleQueries(array(), array('strategy' => 'stopIfEnoughMatches'));
         $this->assertArraySubset(array('results' => array()), $result);
         $result = $client->multipleQueries(array(
-            array('indexName' => static::$indexes['europe']),
-            array('indexName' => static::$indexes['america']),
+            array('indexName' => static::$indexes['europe'], 'params' => array('tagFilters' => '')),
+            array('indexName' => static::$indexes['america'], 'params' => array('tagFilters' => '')),
         ));
         $this->assertGreaterThan(0, count($result['results'][0]['hits']));
         $this->assertGreaterThan(0, count($result['results'][1]['hits']));


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | Fix #624
| Need Doc update   | no

This PR deals with the changes proposed in PR #637 with the following additions :
- serializeQueryParameters has been moved to Helpers class
- null coalescing operator has been changed to an old PHP version compliant ternary operator
- removed short syntax for empty array
- the MultipleIndexTest has been updated
