### PR TITLE
fix: Add missing part of the url for stopABTest() method

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -110,7 +110,7 @@ final class AnalyticsClient
             throw new AlgoliaException('Cannot retrieve ABTest because the abtestID is invalid.');
         }
 
-        return $this->api->write('POST', api_path('/2/abtests/%s', $abTestID), array(), $requestOptions);
+        return $this->api->write('POST', api_path('/2/abtests/%s/stop', $abTestID), array(), $requestOptions);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no     

This fix add the missing part of the url called by the stopABTest() method in the AnalyticsClient class
