### PR TITLE
Remove invalid method call

### DIFF
--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -39,17 +39,13 @@ final class GuzzleHttpClient implements HttpClientInterface
                 );
             }
         } catch (ConnectException $e) {
-            if ($e->hasResponse()) {
-                return $e->getResponse();
-            } else {
-                return new Response(
-                    0,
-                    [],
-                    null,
-                    '1.1',
-                    $e->getMessage()
-                );
-            }
+            return new Response(
+                0,
+                [],
+                null,
+                '1.1',
+                $e->getMessage()
+            );
         }
 
         return $response;


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

I'm removing a call to existent method `ConnectException::hasResponse()`
When a connection fails, there cannot be a response: the client would
have to be connected to get one. Therefore, it would make no sense to
have a `hasResponse()` method on `ConnectException`.

## What problem is this fixing?

This fixes a crash that can happen in case of connection issues.
