### PR TITLE
feat: always cast decompoundedAttributes to object

### DIFF
--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -17,6 +17,7 @@ use Algolia\AlgoliaSearch\Response\MultiResponse;
 use Algolia\AlgoliaSearch\Response\NullResponse;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\Support\Helpers;
+use spec\Prophecy\Exception\Prophecy\ObjectProphecyExceptionSpec;
 
 class SearchIndex
 {
@@ -110,12 +111,31 @@ class SearchIndex
         $response = $this->api->write(
             'PUT',
             api_path('/1/indexes/%s/settings', $this->indexName),
-            $settings,
+            $this->castSettings($settings),
             $requestOptions,
             $default
         );
 
         return new IndexingResponse($response, $this);
+    }
+
+    private function castSettings($settings = [])
+    {
+        $casts = [
+            'decompoundedAttributes' => 'object',
+        ];
+
+        foreach ($settings as $key => $value) {
+            if (array_key_exists($key, $casts)) {
+                switch ($casts[$key]) {
+                    case 'object':
+                        $settings[$key] = (object) $value;
+                        break;
+                }
+            }
+        }
+
+        return $settings;
     }
 
     public function getObject($objectId, $requestOptions = [])

--- a/src/SearchIndex.php
+++ b/src/SearchIndex.php
@@ -17,7 +17,6 @@ use Algolia\AlgoliaSearch\Response\MultiResponse;
 use Algolia\AlgoliaSearch\Response\NullResponse;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\Support\Helpers;
-use spec\Prophecy\Exception\Prophecy\ObjectProphecyExceptionSpec;
 
 class SearchIndex
 {

--- a/tests/Integration/SearchIndexTest.php
+++ b/tests/Integration/SearchIndexTest.php
@@ -260,6 +260,11 @@ class SearchIndexTest extends BaseTest
         /* Check new values from getSettings method */
         $fetchedSettings = $settingsIndex->getSettings();
         $this->assertEquals($settings, $fetchedSettings);
+
+        /* Ensure a setSettings call also works when `decompoundedAttributes` is an empty array */
+        $settingsIndex->setSettings([
+            'decompoundedAttributes' => [],
+        ]);
     }
 
     public function testSearch()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
The engine only accepts objects when setting the `decompoundedAttributes` setting when performing a `setSettings`. This normally goes well since PHP encodes associative arrays to objects. If the array is empty, however, it will be encoded as an array. This PR introduces a change so that during `setSettings`, we always cast `decompoundedAttributes` to an object.