### PR TITLE
feat: add search alias for multiple queries

### DIFF
--- a/src/SearchClient.php
+++ b/src/SearchClient.php
@@ -154,6 +154,11 @@ class SearchClient
         return $this->api->read('GET', api_path('/1/isalive'), $requestOptions);
     }
 
+    public function search($queries, $requestOptions = [])
+    {
+        return $this->multipleQueries($queries, $requestOptions);
+    }
+
     public function multipleQueries($queries, $requestOptions = [])
     {
         $queries = array_map(function ($query) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

This adds `search()` method as an alias for the `multiplequeries()` method to align method names across all API clients.