### PR TITLE
Fix psr/log issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #691
| Need Doc update   | no


## Describe your change
Updating composer.json to allow psr/log 1  & 2

## What problem is this fixing?
```
composer require algolia/algoliasearch-client-php
Using version ^3.1 for algolia/algoliasearch-client-php
./composer.json has been updated
Running composer update algolia/algoliasearch-client-php
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires algolia/algoliasearch-client-php ^3.1 -> satisfiable by algolia/algoliasearch-client-php[3.1.0].
    - algolia/algoliasearch-client-php 3.1.0 requires psr/log ^1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
You can also try re-running composer require with an explicit version constraint, e.g. "composer require algolia/algoliasearch-client-php:*" to figure out if any version is installable, or "composer require algolia/algoliasearch-client-php:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```