### PR TITLE
Corrected saveObjects call example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $client = Algolia\AlgoliaSearch\SearchClient::create(
 
 $index = $client->initIndex('your_index_name');
 
-$index->saveObjects(['objectID' => 1, 'name' => 'Foo']);
+$index->saveObject(['objectID' => 1, 'name' => 'Foo']);
 ```
 
 Finally, you may begin searching a object using the `search` method:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     | Fixes no existing issue
| Need Doc update   | no


## Describe your change

The provided example used a single dimensional array as an argument for the `saveObjects()` method.
As saveObjects saves an array of objects, it generated an error.
I updated the example to use a single `saveObject()` method, which I find easier to understand as a beginner than a two-dimensional array argument for `saveObjects()`