### PR TITLE
Fixes deprecation alert when using symfony/error-handler

### DIFF
--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -67,6 +67,9 @@ class Request implements RequestInterface
         }
     }
 
+    /**
+     * @return string|null
+     */
     public function getRequestTarget()
     {
         if (null !== $this->requestTarget) {
@@ -84,6 +87,9 @@ class Request implements RequestInterface
         return $target;
     }
 
+    /**
+     * @return Request
+     */
     public function withRequestTarget($requestTarget)
     {
         if (preg_match('#\s#', $requestTarget)) {
@@ -96,11 +102,17 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return string
+     */
     public function getMethod()
     {
         return $this->method;
     }
 
+    /**
+     * @return Request
+     */
     public function withMethod($method)
     {
         $new = clone $this;
@@ -109,11 +121,17 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return Uri|UriInterface|string
+     */
     public function getUri()
     {
         return $this->uri;
     }
 
+    /**
+     * @return $this|Request
+     */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
         if ($uri === $this->uri) {
@@ -130,6 +148,9 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return void
+     */
     private function updateHostFromUri()
     {
         $host = $this->uri->getHost();
@@ -153,11 +174,17 @@ class Request implements RequestInterface
         $this->headers = [$header => [$host]] + $this->headers;
     }
 
+    /**
+     * @return string
+     */
     public function getProtocolVersion()
     {
         return $this->protocol;
     }
 
+    /**
+     * @return $this|Request
+     */
     public function withProtocolVersion($version)
     {
         if ($this->protocol === $version) {
@@ -169,16 +196,25 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return array
+     */
     public function getHeaders()
     {
         return $this->headers;
     }
 
+    /**
+     * @return bool
+     */
     public function hasHeader($header)
     {
         return isset($this->headerNames[strtolower($header)]);
     }
 
+    /**
+     * @return array|mixed
+     */
     public function getHeader($header)
     {
         $header = strtolower($header);
@@ -190,11 +226,17 @@ class Request implements RequestInterface
         return $this->headers[$header];
     }
 
+    /**
+     * @return string
+     */
     public function getHeaderLine($header)
     {
         return implode(', ', $this->getHeader($header));
     }
 
+    /**
+     * @return Request
+     */
     public function withHeader($header, $value)
     {
         if (!is_array($value)) {
@@ -212,6 +254,9 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return Request
+     */
     public function withAddedHeader($header, $value)
     {
         if (!is_array($value)) {
@@ -231,6 +276,9 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return $this|Request
+     */
     public function withoutHeader($header)
     {
         $normalized = strtolower($header);
@@ -244,6 +292,9 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return PumpStream|Stream|StreamInterface
+     */
     public function getBody()
     {
         if (!$this->stream) {
@@ -253,6 +304,9 @@ class Request implements RequestInterface
         return $this->stream;
     }
 
+    /**
+     * @return $this|Request
+     */
     public function withBody(StreamInterface $body)
     {
         if ($body === $this->stream) {
@@ -264,6 +318,9 @@ class Request implements RequestInterface
         return $new;
     }
 
+    /**
+     * @return void
+     */
     private function setHeaders(array $headers)
     {
         $this->headerNames = $this->headers = [];

--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -130,7 +130,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * @return $this|Request
+     * @return Request
      */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
@@ -183,7 +183,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * @return $this|Request
+     * @return Request
      */
     public function withProtocolVersion($version)
     {
@@ -277,7 +277,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * @return $this|Request
+     * @return Request
      */
     public function withoutHeader($header)
     {
@@ -305,7 +305,7 @@ class Request implements RequestInterface
     }
 
     /**
-     * @return $this|Request
+     * @return Request
      */
     public function withBody(StreamInterface $body)
     {

--- a/src/Http/Psr7/Stream.php
+++ b/src/Http/Psr7/Stream.php
@@ -96,6 +96,9 @@ class Stream implements StreamInterface
         }
     }
 
+    /**
+     * @return string
+     */
     public function getContents()
     {
         if (!isset($this->stream)) {
@@ -111,6 +114,9 @@ class Stream implements StreamInterface
         return $contents;
     }
 
+    /**
+     * @return void
+     */
     public function close()
     {
         if (isset($this->stream)) {
@@ -121,6 +127,9 @@ class Stream implements StreamInterface
         }
     }
 
+    /**
+     * @return resource|null
+     */
     public function detach()
     {
         if (!isset($this->stream)) {
@@ -135,6 +144,9 @@ class Stream implements StreamInterface
         return $result;
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getSize()
     {
         if (null !== $this->size) {
@@ -160,21 +172,33 @@ class Stream implements StreamInterface
         return null;
     }
 
+    /**
+     * @return bool
+     */
     public function isReadable()
     {
         return $this->readable;
     }
 
+    /**
+     * @return bool
+     */
     public function isWritable()
     {
         return $this->writable;
     }
 
+    /**
+     * @return bool|mixed
+     */
     public function isSeekable()
     {
         return $this->seekable;
     }
 
+    /**
+     * @return bool
+     */
     public function eof()
     {
         if (!isset($this->stream)) {
@@ -184,6 +208,9 @@ class Stream implements StreamInterface
         return feof($this->stream);
     }
 
+    /**
+     * @return int
+     */
     public function tell()
     {
         if (!isset($this->stream)) {
@@ -199,11 +226,17 @@ class Stream implements StreamInterface
         return $result;
     }
 
+    /**
+     * @return void
+     */
     public function rewind()
     {
         $this->seek(0);
     }
 
+    /**
+     * @return void
+     */
     public function seek($offset, $whence = SEEK_SET)
     {
         if (!isset($this->stream)) {
@@ -217,6 +250,9 @@ class Stream implements StreamInterface
         }
     }
 
+    /**
+     * @return string
+     */
     public function read($length)
     {
         if (!isset($this->stream)) {
@@ -241,6 +277,9 @@ class Stream implements StreamInterface
         return $string;
     }
 
+    /**
+     * @return int
+     */
     public function write($string)
     {
         if (!isset($this->stream)) {
@@ -261,6 +300,9 @@ class Stream implements StreamInterface
         return $result;
     }
 
+    /**
+     * @return array|mixed|null
+     */
     public function getMetadata($key = null)
     {
         if (!isset($this->stream)) {

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -458,7 +458,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withScheme($scheme)
     {
@@ -477,7 +477,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withUserInfo($user, $password = null)
     {
@@ -498,7 +498,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withHost($host)
     {
@@ -516,7 +516,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withPort($port)
     {
@@ -535,7 +535,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withPath($path)
     {
@@ -553,7 +553,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withQuery($query)
     {
@@ -570,7 +570,7 @@ class Uri implements UriInterface
     }
 
     /**
-     * @return $this|Uri
+     * @return Uri
      */
     public function withFragment($fragment)
     {

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -384,11 +384,17 @@ class Uri implements UriInterface
         return $uri;
     }
 
+    /**
+     * @return string
+     */
     public function getScheme()
     {
         return $this->scheme;
     }
 
+    /**
+     * @return string
+     */
     public function getAuthority()
     {
         $authority = $this->host;
@@ -403,36 +409,57 @@ class Uri implements UriInterface
         return $authority;
     }
 
+    /**
+     * @return string
+     */
     public function getUserInfo()
     {
         return $this->userInfo;
     }
 
+    /**
+     * @return string
+     */
     public function getHost()
     {
         return $this->host;
     }
 
+    /**
+     * @return int|null
+     */
     public function getPort()
     {
         return $this->port;
     }
 
+    /**
+     * @return string
+     */
     public function getPath()
     {
         return $this->path;
     }
 
+    /**
+     * @return string
+     */
     public function getQuery()
     {
         return $this->query;
     }
 
+    /**
+     * @return string
+     */
     public function getFragment()
     {
         return $this->fragment;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withScheme($scheme)
     {
         $scheme = $this->filterScheme($scheme);
@@ -449,6 +476,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withUserInfo($user, $password = null)
     {
         $info = $user;
@@ -467,6 +497,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withHost($host)
     {
         $host = $this->filterHost($host);
@@ -482,6 +515,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withPort($port)
     {
         $port = $this->filterPort($port);
@@ -498,6 +534,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withPath($path)
     {
         $path = $this->filterPath($path);
@@ -513,6 +552,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withQuery($query)
     {
         $query = $this->filterQueryAndFragment($query);
@@ -527,6 +569,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    /**
+     * @return $this|Uri
+     */
     public function withFragment($fragment)
     {
         $fragment = $this->filterQueryAndFragment($fragment);

--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -21,6 +21,7 @@ abstract class AbstractResponse implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
@@ -30,6 +31,7 @@ abstract class AbstractResponse implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
@@ -39,6 +41,7 @@ abstract class AbstractResponse implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -48,6 +51,7 @@ abstract class AbstractResponse implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/src/Response/BatchIndexingResponse.php
+++ b/src/Response/BatchIndexingResponse.php
@@ -47,30 +47,45 @@ final class BatchIndexingResponse extends AbstractResponse implements \Iterator,
         return count($this->apiResponse);
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->apiResponse[$this->key];
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
         $this->key++;
     }
 
+    /**
+     * @return bool|float|int|mixed|string|null
+     */
     #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->apiResponse[$this->key]);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {

--- a/src/Response/MultiResponse.php
+++ b/src/Response/MultiResponse.php
@@ -20,36 +20,54 @@ class MultiResponse extends AbstractResponse implements \Iterator, \Countable
         return $this;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->apiResponse);
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->apiResponse[$this->key];
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
         $this->key++;
     }
 
+    /**
+     * @return bool|float|int|mixed|string|null
+     */
     #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->apiResponse[$this->key]);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no  
| BC breaks?        | no     
| Related Issue     | Fix #701 
| Need Doc update   | no


## Describe your change

Added PHPDoc @returns to some methods to prevent a deprecation alert when using symfony/error-handler