### PR TITLE
Use interface for constructor arguments

### DIFF
--- a/src/InsightsClient.php
+++ b/src/InsightsClient.php
@@ -5,12 +5,13 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\InsightsConfig;
 use Algolia\AlgoliaSearch\Insights\UserInsightsClient;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 final class InsightsClient
 {
     /**
-     * @var \Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -19,7 +20,7 @@ final class InsightsClient
      */
     private $config;
 
-    public function __construct(ApiWrapper $api, InsightsConfig $config)
+    public function __construct(ApiWrapperInterface $api, InsightsConfig $config)
     {
         $this->api = $api;
         $this->config = $config;

--- a/src/PersonalizationClient.php
+++ b/src/PersonalizationClient.php
@@ -5,12 +5,13 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\PersonalizationConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 final class PersonalizationClient
 {
     /**
-     * @var \Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -22,7 +23,7 @@ final class PersonalizationClient
     /**
      * RecommendationClient constructor.
      */
-    public function __construct(ApiWrapper $api, PersonalizationConfig $config)
+    public function __construct(ApiWrapperInterface $api, PersonalizationConfig $config)
     {
         $this->api = $api;
         $this->config = $config;

--- a/src/RecommendClient.php
+++ b/src/RecommendClient.php
@@ -5,7 +5,7 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\RecommendConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
-use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 final class RecommendClient
@@ -14,7 +14,7 @@ final class RecommendClient
     const BOUGHT_TOGETHER = 'bought-together';
 
     /**
-     * @var ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -23,7 +23,7 @@ final class RecommendClient
      */
     private $config;
 
-    public function __construct(ApiWrapper $api, RecommendConfig $config)
+    public function __construct(ApiWrapperInterface $api, RecommendConfig $config)
     {
         $this->api = $api;
         $this->config = $config;

--- a/src/RecommendationClient.php
+++ b/src/RecommendationClient.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\RecommendationConfig;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 
 /**
@@ -13,7 +14,7 @@ use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 final class RecommendationClient
 {
     /**
-     * @var \Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper
+     * @var ApiWrapperInterface
      */
     private $api;
 
@@ -25,7 +26,7 @@ final class RecommendationClient
     /**
      * RecommendationClient constructor.
      */
-    public function __construct(ApiWrapper $api, RecommendationConfig $config)
+    public function __construct(ApiWrapperInterface $api, RecommendationConfig $config)
     {
         $this->api = $api;
         $this->config = $config;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Using interface for constructor arguments in clients that wasn't updated when introducing interface

## What problem is this fixing?

This allows developers to easily mock the clients (and the underlying APIWrapper)
