### PR TITLE
Fix class not found error

### DIFF
--- a/src/RecommendClient.php
+++ b/src/RecommendClient.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch;
 use Algolia\AlgoliaSearch\Config\RecommendConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
 use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapperInterface;
 use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | Related to PR #704 
| Need Doc update   | no

The ApiWrapper class was no longer imported and thus a fatal error is thrown
