### PR TITLE
Include input string in message about invalid json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-php/compare/3.3.2...master)
 
+### Added
+
+- Include input string in message about invalid json ([#711](https://github.com/algolia/algoliasearch-client-php/pull/711))
+
 ## [v3.3.2](https://github.com/algolia/algoliasearch-client-php/compare/3.3.1...3.3.2)
 
 ### Fixed

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -109,7 +109,15 @@ final class Helpers
     {
         $data = \json_decode($json, $assoc, $depth);
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new \InvalidArgumentException('json_decode error: '.json_last_error_msg());
+            throw new \InvalidArgumentException(sprintf(
+                <<<'EXCEPTION'
+json_decode_error: %s
+input string: %s
+EXCEPTION
+            ,
+                json_last_error_msg(),
+                $json
+            ));
         }
 
         return $data;

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -79,4 +79,12 @@ class HelpersTest extends TestCase
         $objects = [['name' => 'test'], ['primary' => 1, 'name' => 'cool']];
         Helpers::mapObjectIDs('primary', $objects);
     }
+
+    public function testItMentionsTheInputStringWhenItIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('this is not valid json');
+
+        Helpers::json_decode('this is not valid json');
+    }
 }


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

In this PR, we include the input string that is fed to `json_decode`, because it will help understanding issues with it.

## What problem is this fixing?

This helper is used in a single place, to decode the response coming from Algolia. If the response is invalid, the contents of the input string is lost, making it impossible to troubleshoot the error.

Here is an example of what I am currently experiencing in my application:

`json_decode error: Control character error, possibly incorrectly encoded`

I don't think there is a way for me to troubleshoot this.