### PR TITLE
Add referer header.

### DIFF
--- a/src/RequestOptions/RequestOptionsFactory.php
+++ b/src/RequestOptions/RequestOptionsFactory.php
@@ -70,6 +70,9 @@ final class RequestOptionsFactory
                 'X-Algolia-API-Key' => $this->config->getApiKey(),
                 'User-Agent' => UserAgent::get(),
                 'Content-Type' => 'application/json',
+                // For Algolia API restriction, add referer.
+                // See: https://discourse.algolia.com/t/api-key-referrer-restrictions-do-not-work/6574/3
+                'referer' => $_SERVER['HTTP_HOST'],                
             ],
             'query' => [],
             'body' => [],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes   <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes   
| Related Issue     | Fixed #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Add "referer" header before sending out request.

## What problem is this fixing?

In order to prevent Algolia indexing from dev instances, we need a way to restrict indexing from only the live site.
Algolia provides a feature for API restriction, which can be used to restrict a site to interact with the index by defining a narrow privilege API. 

However, this feature requires to set the referer header in order to work, the site has to send the "referer" header along with the request. 

Currently, this module doesn't set the referer header. This patch fixes this by adding adding header, the referer, before sending out the request.
