### PR TITLE
Add support for psr/http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },

--- a/src/Http/Psr7/BufferStream.php
+++ b/src/Http/Psr7/BufferStream.php
@@ -32,12 +32,12 @@ class BufferStream implements StreamInterface
         $this->hwm = $hwm;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContents();
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $buffer = $this->buffer;
         $this->buffer = '';
@@ -45,7 +45,7 @@ class BufferStream implements StreamInterface
         return $buffer;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->buffer = '';
     }
@@ -55,42 +55,42 @@ class BufferStream implements StreamInterface
         $this->close();
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return strlen($this->buffer);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return true;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a BufferStream');
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return 0 === strlen($this->buffer);
     }
 
-    public function tell()
+    public function tell(): int
     {
         throw new \RuntimeException('Cannot determine the position of a BufferStream');
     }
@@ -98,7 +98,7 @@ class BufferStream implements StreamInterface
     /**
      * Reads data from the buffer.
      */
-    public function read($length)
+    public function read(int $length): string
     {
         $currentLength = strlen($this->buffer);
 
@@ -118,7 +118,7 @@ class BufferStream implements StreamInterface
     /**
      * Writes data to the buffer.
      */
-    public function write($string)
+    public function write(string $string): int
     {
         $this->buffer .= $string;
 
@@ -130,7 +130,7 @@ class BufferStream implements StreamInterface
         return strlen($string);
     }
 
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if ('hwm' == $key) {
             return $this->hwm;

--- a/src/Http/Psr7/PumpStream.php
+++ b/src/Http/Psr7/PumpStream.php
@@ -51,7 +51,7 @@ class PumpStream implements StreamInterface
         $this->buffer = new BufferStream();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             return copy_to_string($this);
@@ -60,7 +60,7 @@ class PumpStream implements StreamInterface
         }
     }
 
-    public function close()
+    public function close(): void
     {
         $this->detach();
     }
@@ -71,52 +71,52 @@ class PumpStream implements StreamInterface
         $this->source = null;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
 
-    public function tell()
+    public function tell(): int
     {
         return $this->tellPos;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return !$this->source;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a PumpStream');
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function write($string)
+    public function write(string $string): int
     {
         throw new \RuntimeException('Cannot write to a PumpStream');
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function read($length)
+    public function read(int $length): string
     {
         $data = $this->buffer->read($length);
         $readLen = strlen($data);
@@ -132,7 +132,7 @@ class PumpStream implements StreamInterface
         return $data;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $result = '';
         while (!$this->eof()) {
@@ -142,13 +142,13 @@ class PumpStream implements StreamInterface
         return $result;
     }
 
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if (!$key) {
             return $this->metadata;
         }
 
-        return isset($this->metadata[$key]) ? $this->metadata[$key] : null;
+        return $this->metadata[$key] ?? null;
     }
 
     private function pump($length)

--- a/src/Http/Psr7/Request.php
+++ b/src/Http/Psr7/Request.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
 use InvalidArgumentException;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -70,7 +71,7 @@ class Request implements RequestInterface
     /**
      * @return string|null
      */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         if (null !== $this->requestTarget) {
             return $this->requestTarget;
@@ -90,7 +91,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget): RequestInterface
     {
         if (preg_match('#\s#', $requestTarget)) {
             throw new InvalidArgumentException('Invalid request target provided; cannot contain whitespace');
@@ -105,7 +106,7 @@ class Request implements RequestInterface
     /**
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -113,7 +114,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withMethod($method)
+    public function withMethod(string $method): RequestInterface
     {
         $new = clone $this;
         $new->method = strtoupper($method);
@@ -124,7 +125,7 @@ class Request implements RequestInterface
     /**
      * @return Uri|UriInterface|string
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->uri;
     }
@@ -132,7 +133,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
     {
         if ($uri === $this->uri) {
             return $this;
@@ -177,7 +178,7 @@ class Request implements RequestInterface
     /**
      * @return string
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -185,7 +186,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         if ($this->protocol === $version) {
             return $this;
@@ -199,7 +200,7 @@ class Request implements RequestInterface
     /**
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -207,49 +208,49 @@ class Request implements RequestInterface
     /**
      * @return bool
      */
-    public function hasHeader($header)
+    public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower($name)]);
     }
 
     /**
      * @return array|mixed
      */
-    public function getHeader($header)
+    public function getHeader(string $name): array
     {
-        $header = strtolower($header);
-        if (!isset($this->headerNames[$header])) {
+        $name = strtolower($name);
+        if (!isset($this->headerNames[$name])) {
             return [];
         }
-        $header = $this->headerNames[$header];
+        $name = $this->headerNames[$name];
 
-        return $this->headers[$header];
+        return $this->headers[$name];
     }
 
     /**
      * @return string
      */
-    public function getHeaderLine($header)
+    public function getHeaderLine(string $name): string
     {
-        return implode(', ', $this->getHeader($header));
+        return implode(', ', $this->getHeader($name));
     }
 
     /**
-     * @return Request
+     * @inheritDoc
      */
-    public function withHeader($header, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
             unset($new->headers[$new->headerNames[$normalized]]);
         }
-        $new->headerNames[$normalized] = $header;
-        $new->headers[$header] = $value;
+        $new->headerNames[$normalized] = $name;
+        $new->headers[$name] = $value;
 
         return $new;
     }
@@ -257,20 +258,20 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
-            $header = $this->headerNames[$normalized];
-            $new->headers[$header] = array_merge($this->headers[$header], $value);
+            $name = $this->headerNames[$normalized];
+            $new->headers[$name] = array_merge($this->headers[$name], $value);
         } else {
-            $new->headerNames[$normalized] = $header;
-            $new->headers[$header] = $value;
+            $new->headerNames[$normalized] = $name;
+            $new->headers[$name] = $value;
         }
 
         return $new;
@@ -279,15 +280,15 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withoutHeader($header)
+    public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         if (!isset($this->headerNames[$normalized])) {
             return $this;
         }
-        $header = $this->headerNames[$normalized];
+        $name = $this->headerNames[$normalized];
         $new = clone $this;
-        unset($new->headers[$header], $new->headerNames[$normalized]);
+        unset($new->headers[$name], $new->headerNames[$normalized]);
 
         return $new;
     }
@@ -295,7 +296,7 @@ class Request implements RequestInterface
     /**
      * @return PumpStream|Stream|StreamInterface
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         if (!$this->stream) {
             $this->stream = stream_for('');
@@ -307,7 +308,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         if ($body === $this->stream) {
             return $this;

--- a/src/Http/Psr7/Response.php
+++ b/src/Http/Psr7/Response.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Http\Psr7;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -128,7 +129,7 @@ class Response implements ResponseInterface
     /**
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
@@ -136,7 +137,7 @@ class Response implements ResponseInterface
     /**
      * @return string
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;
     }
@@ -144,7 +145,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
         $new = clone $this;
         $new->statusCode = (int) $code;
@@ -159,7 +160,7 @@ class Response implements ResponseInterface
     /**
      * @return string
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -167,7 +168,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         if ($this->protocol === $version) {
             return $this;
@@ -182,7 +183,7 @@ class Response implements ResponseInterface
     /**
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -190,53 +191,53 @@ class Response implements ResponseInterface
     /**
      * @return bool
      */
-    public function hasHeader($header)
+    public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower($name)]);
     }
 
     /**
      * @return array
      */
-    public function getHeader($header)
+    public function getHeader(string $name): array
     {
-        $header = strtolower($header);
+        $name = strtolower($name);
 
-        if (!isset($this->headerNames[$header])) {
+        if (!isset($this->headerNames[$name])) {
             return [];
         }
 
-        $header = $this->headerNames[$header];
+        $name = $this->headerNames[$name];
 
-        return $this->headers[$header];
+        return $this->headers[$name];
     }
 
     /**
      * @return string
      */
-    public function getHeaderLine($header)
+    public function getHeaderLine(string $name): string
     {
-        return implode(', ', $this->getHeader($header));
+        return implode(', ', $this->getHeader($name));
     }
 
     /**
      * @return static
      */
-    public function withHeader($header, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
 
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
             unset($new->headers[$new->headerNames[$normalized]]);
         }
-        $new->headerNames[$normalized] = $header;
-        $new->headers[$header] = $value;
+        $new->headerNames[$normalized] = $name;
+        $new->headers[$name] = $value;
 
         return $new;
     }
@@ -244,22 +245,22 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
 
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
-            $header = $this->headerNames[$normalized];
-            $new->headers[$header] = array_merge($this->headers[$header], $value);
+            $name = $this->headerNames[$normalized];
+            $new->headers[$name] = array_merge($this->headers[$name], $value);
         } else {
-            $new->headerNames[$normalized] = $header;
-            $new->headers[$header] = $value;
+            $new->headerNames[$normalized] = $name;
+            $new->headers[$name] = $value;
         }
 
         return $new;
@@ -268,26 +269,26 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withoutHeader($header)
+    public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
         }
 
-        $header = $this->headerNames[$normalized];
+        $name = $this->headerNames[$normalized];
 
         $new = clone $this;
-        unset($new->headers[$header], $new->headerNames[$normalized]);
+        unset($new->headers[$name], $new->headerNames[$normalized]);
 
         return $new;
     }
 
     /**
-     * @return \StreamInterface
+     * @return StreamInterface
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         if (!$this->stream) {
             $this->stream = stream_for('');
@@ -299,7 +300,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         if ($body === $this->stream) {
             return $this;

--- a/src/Http/Psr7/Stream.php
+++ b/src/Http/Psr7/Stream.php
@@ -85,7 +85,7 @@ class Stream implements StreamInterface
         $this->close();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             $this->seek(0);
@@ -99,7 +99,7 @@ class Stream implements StreamInterface
     /**
      * @return string
      */
-    public function getContents()
+    public function getContents(): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -117,7 +117,7 @@ class Stream implements StreamInterface
     /**
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         if (isset($this->stream)) {
             if (is_resource($this->stream)) {
@@ -147,7 +147,7 @@ class Stream implements StreamInterface
     /**
      * @return mixed|null
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         if (null !== $this->size) {
             return $this->size;
@@ -175,7 +175,7 @@ class Stream implements StreamInterface
     /**
      * @return bool
      */
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable;
     }
@@ -183,7 +183,7 @@ class Stream implements StreamInterface
     /**
      * @return bool
      */
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
@@ -191,7 +191,7 @@ class Stream implements StreamInterface
     /**
      * @return bool|mixed
      */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->seekable;
     }
@@ -199,7 +199,7 @@ class Stream implements StreamInterface
     /**
      * @return bool
      */
-    public function eof()
+    public function eof(): bool
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -211,7 +211,7 @@ class Stream implements StreamInterface
     /**
      * @return int
      */
-    public function tell()
+    public function tell(): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -229,7 +229,7 @@ class Stream implements StreamInterface
     /**
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
@@ -237,7 +237,7 @@ class Stream implements StreamInterface
     /**
      * @return void
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -253,7 +253,7 @@ class Stream implements StreamInterface
     /**
      * @return string
      */
-    public function read($length)
+    public function read(int $length): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -280,7 +280,7 @@ class Stream implements StreamInterface
     /**
      * @return int
      */
-    public function write($string)
+    public function write(string $string): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -303,7 +303,7 @@ class Stream implements StreamInterface
     /**
      * @return array|mixed|null
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if (!isset($this->stream)) {
             return $key ? null : [];
@@ -315,6 +315,6 @@ class Stream implements StreamInterface
 
         $meta = stream_get_meta_data($this->stream);
 
-        return isset($meta[$key]) ? $meta[$key] : null;
+        return $meta[$key] ?? null;
     }
 }

--- a/src/Http/Psr7/Uri.php
+++ b/src/Http/Psr7/Uri.php
@@ -81,7 +81,7 @@ class Uri implements UriInterface
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return self::composeComponents(
             $this->scheme,
@@ -387,7 +387,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
@@ -395,7 +395,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getAuthority()
+    public function getAuthority(): string
     {
         $authority = $this->host;
         if ('' !== $this->userInfo) {
@@ -412,7 +412,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return $this->userInfo;
     }
@@ -420,7 +420,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
@@ -428,7 +428,7 @@ class Uri implements UriInterface
     /**
      * @return int|null
      */
-    public function getPort()
+    public function getPort(): ?int
     {
         return $this->port;
     }
@@ -436,7 +436,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -444,7 +444,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getQuery()
+    public function getQuery(): string
     {
         return $this->query;
     }
@@ -452,7 +452,7 @@ class Uri implements UriInterface
     /**
      * @return string
      */
-    public function getFragment()
+    public function getFragment(): string
     {
         return $this->fragment;
     }
@@ -460,7 +460,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withScheme($scheme)
+    public function withScheme(string $scheme): UriInterface
     {
         $scheme = $this->filterScheme($scheme);
 
@@ -479,7 +479,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo(string $user, ?string $password = null): UriInterface
     {
         $info = $user;
         if ('' != $password) {
@@ -500,7 +500,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withHost($host)
+    public function withHost(string $host): UriInterface
     {
         $host = $this->filterHost($host);
 
@@ -518,7 +518,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withPort($port)
+    public function withPort(?int $port): UriInterface
     {
         $port = $this->filterPort($port);
 
@@ -537,7 +537,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withPath($path)
+    public function withPath(string $path): UriInterface
     {
         $path = $this->filterPath($path);
 
@@ -555,7 +555,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withQuery($query)
+    public function withQuery(string $query): UriInterface
     {
         $query = $this->filterQueryAndFragment($query);
 
@@ -572,7 +572,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withFragment($fragment)
+    public function withFragment(string $fragment): UriInterface
     {
         $fragment = $this->filterQueryAndFragment($fragment);
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | ...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

This introcues support for psr/http-message 2.0 while keeping support for 1.0.

The only change in psr/http-message:2.0 introduces return types. As we support php:^7.2 we can also introduce these to support both 1.0 & 2.0. This also realigns paramater names with their interface definitions to better support named arguments (introduced in php:^8.0).

## What problem is this fixing?

Allows inclusion in projects that require psr/http-message:^2.0
