### PR TITLE
fix: use spread operator instead of call_user_func_array to be compat…

### DIFF
--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -31,7 +31,7 @@ final class Helpers
         }
         array_unshift($arguments, $pathFormat);
 
-        return call_user_func_array('sprintf', $arguments);
+        return sprintf(...$arguments);
     }
 
     /**


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | https://github.com/humbug/php-scoper/issues/294
| Need Doc update   | no

## Describe your change

Use `sprintf()` with spread operator instead of `call_user_func_array()`.

## What problem is this fixing?

When using https://github.com/humbug/php-scoper it modifies the following code:

```php
return call_user_func_array('sprintf', $arguments);
```

to:

```php
return \call_user_func_array('PhpScoper\\Vendor\\sprintf', $arguments);
```

This leads to an PHP fatal error as the `PhpScoper\Vendor\sprintf` function is not available.